### PR TITLE
Option to disable mDNS service advertisement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ The following environment variables exist in addition to the configuration file:
 | Variable                     | Values               | Description                                                                                                 |
 |------------------------------|----------------------|-------------------------------------------------------------------------------------------------------------|
 | UC_CONFIG_HOME               | _directory path_     | Configuration directory to save the user configuration from the driver setup.<br>Default: current directory |
+| UC_DISABLE_MDNS_PUBLISH      | `true` / `false`     | Disables mDNS service advertisement.<br>Default: `false`                                                    |
 | UC_USER_CFG_FILENAME         | _filename_           | JSON configuration filename for the user settings.<br>Default: `home-assistant.json`                        |
 | UC_DISABLE_CERT_VERIFICATION | `true` / `false`     | Disables certificate verification for the Home Assistant WS connection.<br>Default: `false`                 |
 | UC_API_MSG_TRACING           | `all` / `in` / `out` | Enables incoming and outgoing WS Core-API message tracing<br>Default: no tracing                            |
 | UC_HASS_MSG_TRACING          | `all` / `in` / `out` | Enables incoming and outgoing Home Assistant WS message tracing<br>Default: no tracing                      |
 
 On the Remote Two device, the integration is configured for the embedded runtime environment with several environment
-variables. Mainly `UC_CONFIG_HOME` and some `UC_INTEGRATION_*`.
+variables. Mainly `UC_DISABLE_MDNS_PUBLISH=true`, `UC_CONFIG_HOME` and some `UC_INTEGRATION_*` to listen on the local
+interface only.
 
 ## How to Build and Run
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -20,7 +20,7 @@ use url::Url;
 
 use crate::client::messages::{ConnectionEvent, ConnectionState};
 use crate::client::model::Event;
-use crate::configuration::HeartbeatSettings;
+use crate::configuration::{HeartbeatSettings, ENV_HASS_MSG_TRACING};
 use crate::errors::ServiceError;
 use crate::Controller;
 
@@ -73,7 +73,7 @@ impl HomeAssistantClient {
             let scheme = url.scheme();
             let host = url.host_str().unwrap_or(url.as_str());
             let port = url.port_or_known_default().unwrap_or_default();
-            let msg_tracing = env::var("UC_HASS_MSG_TRACING").unwrap_or_default();
+            let msg_tracing = env::var(ENV_HASS_MSG_TRACING).unwrap_or_default();
             HomeAssistantClient {
                 id: format!("{}:{}", host, port),
                 server: {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -21,7 +21,39 @@ pub const DEF_SETUP_TIMEOUT_SEC: u64 = 300;
 
 const ENV_USER_CFG_FILENAME: &str = "UC_USER_CFG_FILENAME";
 const DEV_USER_CFG_FILENAME: &str = "home-assistant.json";
+
+/// Environment variable for the user configuration directory.
+///
+/// This ENV variable is set on the Remote device to the integration specific data directory.
 const ENV_CONFIG_HOME: &str = "UC_CONFIG_HOME";
+
+/// Environment variable to disable mDNS service publishing.
+///
+/// When running on the Remote device, service publishing is not required.
+pub const ENV_DISABLE_MDNS_PUBLISH: &str = "UC_DISABLE_MDNS_PUBLISH";
+
+/// Environment variable to enable Home Assistant server WebSocket message tracing.
+///
+/// Valid values:
+/// - `all`: enable incoming and outgoing message traces
+/// - `in`: only incoming messages
+/// - `out`: only outgoing messages
+///
+/// **Attention:** this setting is only for debugging and exposes all data, including credentials!
+pub const ENV_HASS_MSG_TRACING: &str = "UC_HASS_MSG_TRACING";
+
+/// Environment variable to enable Remote Two Integration API WebSocket message tracing.
+///
+/// Valid values:
+/// - `all`: enable incoming and outgoing message traces
+/// - `in`: only incoming messages
+/// - `out`: only outgoing messages
+///
+/// **Attention:** this setting is only for debugging and exposes all data, including credentials!
+pub const ENV_API_MSG_TRACING: &str = "UC_API_MSG_TRACING";
+
+/// Environment variable to disable TLS verification to the Home Assistant server.
+pub const ENV_DISABLE_CERT_VERIFICATION: &str = "UC_DISABLE_CERT_VERIFICATION";
 
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 pub struct Settings {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,12 @@
 #![forbid(non_ascii_idents)]
 #![deny(unsafe_code)]
 
-use crate::configuration::{get_configuration, CertificateSettings, IntegrationSettings};
+use crate::configuration::{
+    get_configuration, CertificateSettings, IntegrationSettings, ENV_DISABLE_MDNS_PUBLISH,
+};
 use crate::controller::Controller;
 use crate::server::publish_service;
-use crate::util::create_single_cert_server_config;
+use crate::util::{bool_from_env, create_single_cert_server_config};
 use actix::Actor;
 use actix_web::{middleware, web, App, HttpServer};
 use clap::{arg, Command};
@@ -126,7 +128,9 @@ async fn main() -> io::Result<()> {
         http_server = http_server.listen(listener)?;
     }
 
-    publish_mdns(api_port, driver_metadata);
+    if !bool_from_env(ENV_DISABLE_MDNS_PUBLISH) {
+        publish_mdns(api_port, driver_metadata);
+    }
 
     http_server.run().await?;
 

--- a/src/server/ws/mod.rs
+++ b/src/server/ws/mod.rs
@@ -3,7 +3,7 @@
 
 //! WebSocket server for the Remote Two integration API
 
-use crate::configuration::{HeartbeatSettings, WebSocketSettings};
+use crate::configuration::{HeartbeatSettings, WebSocketSettings, ENV_API_MSG_TRACING};
 use crate::Controller;
 use actix::Addr;
 use actix_web::error::JsonPayloadError;
@@ -43,7 +43,7 @@ impl WsConn {
         controller_addr: Addr<Controller>,
         heartbeat: HeartbeatSettings,
     ) -> Self {
-        let msg_tracing = env::var("UC_API_MSG_TRACING").unwrap_or_default();
+        let msg_tracing = env::var(ENV_API_MSG_TRACING).unwrap_or_default();
         Self {
             id: client_id,
             hb: Instant::now(),

--- a/src/util/network.rs
+++ b/src/util/network.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
 // SPDX-License-Identifier: MPL-2.0
 
+use crate::configuration::ENV_DISABLE_CERT_VERIFICATION;
 use crate::util::bool_from_env;
 use actix_tls::connect::rustls::webpki_roots_cert_store;
 use if_addrs::{IfAddr, Ifv4Addr};
@@ -39,7 +40,7 @@ pub fn new_websocket_client(connection_timeout: Duration, tls: bool) -> awc::Cli
 
         // Disable TLS verification
         // Requires: rustls = { ... optional = true, features = ["dangerous_configuration"] }
-        if bool_from_env("UC_DISABLE_CERT_VERIFICATION") {
+        if bool_from_env(ENV_DISABLE_CERT_VERIFICATION) {
             config
                 .dangerous()
                 .set_certificate_verifier(Arc::new(danger::NoCertificateVerification {}));


### PR DESCRIPTION
When running on the Remote device, mDNS advertisement is not required and should be disabled.
This is handled with the ENV variable UC_DISABLE_MDNS_PUBLISH set to true.