### PR TITLE
Optional zeroconf library for mDNS advertisement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,10 @@ jobs:
       - id: setup
         uses: ./.github/actions/rust-setup
 
-      - run: cargo test
+      - run: cargo test --features mdns-sd
 
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --features mdns-sd -- -D warnings
 
   build:
     name: Build release
@@ -76,7 +76,7 @@ jobs:
 
       - name: Release build
         shell: bash
-        run: cargo build --release
+        run: cargo build --features mdns-sd --release
 
 # This takes over 5 min! Do it manually...
 #      - name: Create license report for releases

--- a/.idea/runConfigurations/Run_intg_home_assistant___mdns_sd_.xml
+++ b/.idea/runConfigurations/Run_intg_home_assistant___mdns_sd_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="doc" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="doc --open  --features zeroconf" />
+  <configuration default="false" name="Run intg-home-assistant  (mdns-sd)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package uc-intg-hass --bin uc-intg-hass --features mdns-sd" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <option name="emulateTerminal" value="false" />
     <option name="channel" value="DEFAULT" />
@@ -9,7 +9,12 @@
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
-    <envs />
+    <envs>
+      <env name="RUST_LOG" value="debug,uc_intg_hass::client=debug,uc_intg_hass::server=debug,mdns_sd=info" />
+      <env name="UC_API_MSG_TRACING" value="all" />
+      <env name="UC_HASS_MSG_TRACING" value="all" />
+      <env name="UC_SETUP_TIMEOUT" value="60" />
+    </envs>
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/.idea/runConfigurations/Run_intg_home_assistant___zeroconf_.xml
+++ b/.idea/runConfigurations/Run_intg_home_assistant___zeroconf_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="doc" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="doc --open  --features zeroconf" />
+  <configuration default="false" name="Run intg-home-assistant  (zeroconf)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --package uc-intg-hass --bin uc-intg-hass --features zeroconf" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <option name="emulateTerminal" value="false" />
     <option name="channel" value="DEFAULT" />
@@ -9,7 +9,12 @@
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
-    <envs />
+    <envs>
+      <env name="RUST_LOG" value="debug,uc_intg_hass::client=debug,uc_intg_hass::server=debug,mdns_sd=info" />
+      <env name="UC_API_MSG_TRACING" value="all" />
+      <env name="UC_HASS_MSG_TRACING" value="all" />
+      <env name="UC_SETUP_TIMEOUT" value="60" />
+    </envs>
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/.idea/runConfigurations/clippy__mdns_sd_.xml
+++ b/.idea/runConfigurations/clippy__mdns_sd_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="clippy" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="clippy" />
+  <configuration default="false" name="clippy (mdns-sd)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="clippy --features mdns-sd" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <option name="emulateTerminal" value="false" />
     <option name="channel" value="DEFAULT" />

--- a/.idea/runConfigurations/clippy__zeroconf_.xml
+++ b/.idea/runConfigurations/clippy__zeroconf_.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run intg-home-assistant" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="run --package uc-intg-hass --bin uc-intg-hass" />
+  <configuration default="false" name="clippy (zeroconf)" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="clippy --features zeroconf" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <option name="emulateTerminal" value="false" />
     <option name="channel" value="DEFAULT" />
@@ -9,12 +9,7 @@
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
-    <envs>
-      <env name="RUST_LOG" value="debug,uc_intg_hass::client=debug,uc_intg_hass::server=debug,mdns_sd=info" />
-      <env name="UC_API_MSG_TRACING" value="all" />
-      <env name="UC_HASS_MSG_TRACING" value="all" />
-      <env name="UC_SETUP_TIMEOUT" value="60" />
-    </envs>
+    <envs />
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ dependencies = [
  "ahash 0.7.6",
  "bytes",
  "bytestring",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cookie",
  "derive_more",
  "encoding_rs",
@@ -280,7 +280,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "getrandom",
  "once_cell",
  "version_check",
@@ -320,6 +320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +357,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "avahi-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f792866e533338be173a9dd8b3510591c69ed43998eb0829890486d4bbd39cf"
+dependencies = [
+ "bindgen",
+ "libc",
+]
+
+[[package]]
 name = "awc"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,7 +381,7 @@ dependencies = [
  "ahash 0.7.6",
  "base64 0.21.0",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cookie",
  "derive_more",
  "futures-core",
@@ -395,6 +414,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bindgen"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "cfg-if 0.1.10",
+ "clang-sys",
+ "clap 2.34.0",
+ "env_logger 0.7.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +450,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bonjour-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb769a9e04063943874cd92039ee81eee55adca48bb9615bc3dff73b57cd5aa"
+dependencies = [
+ "bindgen",
+ "libc",
 ]
 
 [[package]]
@@ -485,6 +538,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom 5.1.3",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +575,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,9 +610,9 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "indexmap",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -547,7 +641,7 @@ checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
 dependencies = [
  "async-trait",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "pathdiff",
  "serde",
  "serde_json",
@@ -612,7 +706,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -621,7 +715,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -631,7 +725,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -646,12 +740,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.1",
+ "darling_macro 0.20.1",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -664,8 +782,19 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.16",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core 0.10.2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -674,9 +803,56 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.1",
  "quote",
  "syn 2.0.16",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0122f262bf9c9a367829da84f808d9fb128c10ef283bbe7b0922a77cf07b2747"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling 0.10.2",
+ "derive_builder_core",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling 0.10.2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -708,7 +884,20 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -717,7 +906,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "humantime",
+ "humantime 2.1.0",
  "is-terminal",
  "log",
  "regex",
@@ -893,7 +1082,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -910,6 +1099,12 @@ dependencies = [
  "log",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1005,6 +1200,15 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "humantime"
@@ -1159,6 +1363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1384,16 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
 ]
 
 [[package]]
@@ -1234,7 +1454,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1298,6 +1518,16 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+dependencies = [
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -1367,7 +1597,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1385,6 +1615,12 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1438,7 +1674,7 @@ checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
  "log",
@@ -1484,6 +1720,12 @@ checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1583,7 +1825,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1609,6 +1851,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1756,7 +2004,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling",
+ "darling 0.20.1",
  "proc-macro2",
  "quote",
  "syn 2.0.16",
@@ -1768,10 +2016,16 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1821,6 +2075,18 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"
@@ -1876,6 +2142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1994,7 +2269,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-core",
@@ -2028,11 +2303,11 @@ dependencies = [
  "built",
  "bytes",
  "bytestring",
- "clap",
+ "clap 3.2.25",
  "config",
  "const_format",
  "derive_more",
- "env_logger",
+ "env_logger 0.10.0",
  "futures",
  "hostname",
  "if-addrs 0.10.1",
@@ -2052,6 +2327,7 @@ dependencies = [
  "uc_api",
  "url",
  "uuid",
+ "zeroconf",
 ]
 
 [[package]]
@@ -2092,6 +2368,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -2174,6 +2456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,7 +2485,7 @@ version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -2272,6 +2560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2453,6 +2750,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zeroconf"
+version = "0.10.5"
+source = "git+https://github.com/ERobsham/zeroconf-rs?rev=a6e399d16dc04f94bf87ef60be222e966b94bd86#a6e399d16dc04f94bf87ef60be222e966b94bd86"
+dependencies = [
+ "avahi-sys",
+ "bonjour-sys",
+ "derive-getters",
+ "derive-new",
+ "derive_builder",
+ "libc",
+ "log",
+ "serde",
+ "zeroconf-macros",
+]
+
+[[package]]
+name = "zeroconf-macros"
+version = "0.1.2"
+source = "git+https://github.com/ERobsham/zeroconf-rs?rev=a6e399d16dc04f94bf87ef60be222e966b94bd86#a6e399d16dc04f94bf87ef60be222e966b94bd86"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ description = "Unfolded Circle Home-Assistant integration for Remote Two"
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.
 
+[features]
+default = []
+mdns-sd = ["dep:mdns-sd"]
+zeroconf = ["dep:zeroconf"]
+
 [dependencies]
 uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.7.1-alpha" }
 #uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", rev = "b92dbde77ea7ff800aab4505547e0792d985430f" }
@@ -31,9 +36,11 @@ bytes = "1"
 futures = "0.3"
 
 # see mdns-sd patch at the end of this file
-mdns-sd = "0.7.3"
+mdns-sd = { version = "0.7.3", optional = true }
 if-addrs = "0.10"
 hostname = "0.3"
+# see zeroconf patch at the end of this file
+zeroconf = { version = "0.10.5", optional = true }
 
 # JSON (de)serialization
 serde = { version = "1", features = ["derive"] }
@@ -66,3 +73,5 @@ rstest = "0.17"
 
 [patch.crates-io]
 mdns-sd = { git = "https://github.com/zehnm/mdns-sd", rev = "401bab9b34f1a79c06b87432071abb2d4a379a75" }
+# PR ERobsham:bugfix/respect_timeout_on_linux
+zeroconf = { git = "https://github.com/ERobsham/zeroconf-rs", rev = "a6e399d16dc04f94bf87ef60be222e966b94bd86" }

--- a/README.md
+++ b/README.md
@@ -50,9 +50,32 @@ interface only.
 
 If you don't have Rust installed yet: <https://www.rust-lang.org/tools/install>
 
-`cargo build` to build.
+### Build
 
-`cargo run` to start the integration driver.
+Without mDNS advertisement support:
+
+```shell
+cargo build
+```
+
+With [zeroconf](https://crates.io/crates/zeroconf) library, wrapping underlying ZeroConf/mDNS implementations such as
+Bonjour on macOS or Avahi on Linux:
+```shell
+cargo build --features zeroconf
+```
+
+With pure Rust [mdns-sd](https://crates.io/crates/mdns-sd) library:
+```shell
+cargo build --features mdns-sd
+```
+This will run on any platform, but with limited functionality (no IPv6 support) and potential incompatibilities.
+
+### Run
+
+To start the integration driver:
+```shell
+cargo run
+```
 
 ## Contributing
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,8 @@ fn publish_mdns(api_port: u16, drv_metadata: IntegrationDriverUpdate) {
         drv_metadata
             .driver_id
             .expect("driver_id must be set in driver metadata"),
-        "_uc-integration._tcp",
+        "uc-integration",
+        "tcp",
         api_port,
         vec![
             format!(

--- a/src/server/mdns.rs
+++ b/src/server/mdns.rs
@@ -1,14 +1,13 @@
 // Copyright (c) 2023 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
 // SPDX-License-Identifier: MPL-2.0
 
-//! mDNS advertisement
+//! mDNS advertisement with mdns-sd Rust crate
 
 use crate::errors::ServiceError;
 use crate::util::my_ipv4_interfaces;
 use lazy_static::lazy_static;
 use log::{error, info};
-use mdns_sd::ServiceDaemon;
-use mdns_sd::ServiceInfo;
+use mdns_sd::{ServiceDaemon, ServiceInfo};
 use std::net::Ipv4Addr;
 
 lazy_static! {
@@ -28,17 +27,19 @@ lazy_static! {
 /// # Arguments
 ///
 /// * `instance_name`: Instance name
-/// * `reg_type`: The service type followed by the protocol, separated by a dot (for example, "_ssh._tcp")
+/// * `service_name`: The service name (e.g. `http`).
+/// * `protocol`: The protocol of the service (e.g. `tcp`).
 /// * `port`: The port on which the service accepts connections.
 /// * `txt`: Optional TXT record data with format: `key=value`. The value is optional.
 pub fn publish_service(
     instance_name: impl AsRef<str>,
-    reg_type: impl Into<String>,
+    service_name: impl AsRef<str>,
+    protocol: impl AsRef<str>,
     port: u16,
     txt: Vec<String>,
 ) -> Result<(), ServiceError> {
     if let Some(mdns_service) = &*MDNS_SERVICE {
-        let mut reg_type = reg_type.into();
+        let mut reg_type = format!("_{}._{}", service_name.as_ref(), protocol.as_ref());
         if !reg_type.ends_with(".local.") {
             reg_type.push_str(".local.");
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,8 +3,30 @@
 
 //! Server modules of the integration driver. Handling WebSocket and mDNS advertisement.
 
-mod mdns;
-mod ws;
+// zeroconf has priority over mdns-sd
+#[cfg(feature = "zeroconf")]
+mod zeroconf;
+#[cfg(feature = "zeroconf")]
+pub use self::zeroconf::publish_service;
 
+#[cfg(feature = "mdns-sd")]
+mod mdns;
+#[cfg(feature = "mdns-sd")]
+#[cfg(not(feature = "zeroconf"))]
 pub use mdns::publish_service;
+
+mod ws;
 pub use ws::{json_error_handler, ws_index};
+
+/// Fallback if no mDNS library is enabled
+#[cfg(not(feature = "zeroconf"))]
+#[cfg(not(feature = "mdns-sd"))]
+pub fn publish_service(
+    _instance_name: impl AsRef<str>,
+    _reg_type: impl Into<String>,
+    _port: u16,
+    _txt: Vec<String>,
+) -> Result<(), crate::errors::ServiceError> {
+    log::warn!("No mDNS library support included: service will not be published!");
+    Ok(())
+}

--- a/src/server/zeroconf.rs
+++ b/src/server/zeroconf.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
+// SPDX-License-Identifier: MPL-2.0
+
+//! mDNS advertisement with Zeroconf (Avahi or Bonjour)
+
+use crate::errors::ServiceError;
+
+use log::{error, info};
+use std::any::Any;
+use std::sync::Arc;
+use std::time::Duration;
+use zeroconf::prelude::*;
+use zeroconf::{MdnsService, ServiceRegistration, ServiceType, TxtRecord};
+
+/// Publish a service on all available network interfaces with the default hostname.
+///
+/// # Arguments
+///
+/// * `instance_name`: Instance name
+/// * `service_name`: The service name (e.g. `http`).
+/// * `protocol`: The protocol of the service (e.g. `tcp`).
+/// * `port`: The port on which the service accepts connections.
+/// * `txt`: Optional TXT record data with format: `key=value`. The value is optional.
+pub fn publish_service(
+    instance_name: impl ToString,
+    service_name: impl AsRef<str>,
+    protocol: impl AsRef<str>,
+    port: u16,
+    txt: Vec<String>,
+) -> Result<(), ServiceError> {
+    let instance_name = instance_name.to_string();
+    let service = ServiceType::new(service_name.as_ref(), protocol.as_ref())
+        .map_err(|e| ServiceError::BadRequest(e.to_string()))?;
+    std::thread::spawn(move || service_publisher(instance_name, service, port, txt));
+
+    Ok(())
+}
+
+/// Publisher thread polling the event loop.
+fn service_publisher(
+    instance_name: String,
+    service_type: ServiceType,
+    port: u16,
+    txt: Vec<String>,
+) {
+    let mut service = MdnsService::new(service_type, port);
+    let mut txt_record = TxtRecord::new();
+
+    for record in txt {
+        if let Some((key, value)) = record.split_once('=') {
+            txt_record.insert(key, value).unwrap();
+        }
+    }
+
+    service.set_name(instance_name.as_ref());
+    service.set_registered_callback(Box::new(on_service_registered));
+    service.set_txt_record(txt_record);
+
+    let event_loop = match service.register() {
+        Ok(el) => el,
+        Err(e) => {
+            error!("Failed to register service! Error: {e}");
+            return;
+        }
+    };
+
+    loop {
+        // What is a good production timeout?
+        event_loop.poll(Duration::from_secs(1)).unwrap();
+    }
+}
+
+fn on_service_registered(
+    result: zeroconf::Result<ServiceRegistration>,
+    _context: Option<Arc<dyn Any>>,
+) {
+    match result {
+        Ok(r) => info!("{:?}", r),
+        Err(e) => error!("Service registration error: {e}"),
+    }
+}

--- a/src/server/zeroconf.rs
+++ b/src/server/zeroconf.rs
@@ -66,7 +66,10 @@ fn service_publisher(
 
     loop {
         // What is a good production timeout?
-        event_loop.poll(Duration::from_secs(1)).unwrap();
+        if let Err(e) = event_loop.poll(Duration::from_secs(1)) {
+            error!("mDNS event loop polling error: {e}");
+            return;
+        }
     }
 }
 

--- a/src/util/network.rs
+++ b/src/util/network.rs
@@ -4,12 +4,12 @@
 use crate::configuration::ENV_DISABLE_CERT_VERIFICATION;
 use crate::util::bool_from_env;
 use actix_tls::connect::rustls::webpki_roots_cert_store;
-use if_addrs::{IfAddr, Ifv4Addr};
 use rustls::ClientConfig;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
+#[cfg(feature = "mdns-sd")]
+pub fn my_ipv4_interfaces() -> Vec<if_addrs::Ifv4Addr> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()
@@ -18,7 +18,7 @@ pub fn my_ipv4_interfaces() -> Vec<Ifv4Addr> {
                 None
             } else {
                 match i.addr {
-                    IfAddr::V4(ifv4) => Some(ifv4),
+                    if_addrs::IfAddr::V4(ifv4) => Some(ifv4),
                     _ => None,
                 }
             }


### PR DESCRIPTION
The zeroconf wrapper library uses the native Avahi C library on Linux and Bonjour on Mac.
This provides IPv6 support and might solve a few recent issues with mdns-sd.