### PR TITLE
refactor: rename media-player `select_sound_mode` command parameter

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Rename media-player `select_sound_mode` command parameter
+
 ---
 
 ## v0.3.0 - 2023-07-17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,7 +2374,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uc-intg-hass"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "actix",
  "actix-codec",

--- a/src/client/service/media_player.rs
+++ b/src/client/service/media_player.rs
@@ -115,11 +115,11 @@ pub fn handle_media_player(msg: &EntityCommand) -> Result<(String, Option<Value>
         MediaPlayerCommand::SelectSoundMode => {
             let mut data = Map::new();
             let params = get_required_params(msg)?;
-            if let Some(mode) = params.get("sound_mode").and_then(|v| v.as_str()) {
+            if let Some(mode) = params.get("mode").and_then(|v| v.as_str()) {
                 data.insert("sound_mode".into(), mode.into());
             } else {
                 return Err(ServiceError::BadRequest(
-                    "Invalid or missing params.sound_mode attribute".into(),
+                    "Invalid or missing params.mode attribute".into(),
                 ));
             }
             ("select_sound_mode".into(), Some(data.into()))


### PR DESCRIPTION
The Core command metadata used `mode` instead of `sound_mode`. To avoid invalid user configurations and risky data migrations, we changed the specification: unfoldedcircle/core-api#30.

Relates to: unfoldedcircle/feature-and-bug-tracker#165