### PR TITLE
fix: allow unlimited reconnection attempts

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -133,7 +133,7 @@ impl Default for HomeAssistantSettings {
 #[serde_as]
 #[derive(Clone, serde::Deserialize, serde::Serialize)]
 pub struct ReconnectSettings {
-    pub attempts: u16,
+    pub attempts: u32,
     #[serde_as(as = "DurationMilliSeconds")]
     #[serde(rename = "duration_ms")]
     pub duration: Duration,
@@ -146,7 +146,7 @@ pub struct ReconnectSettings {
 impl Default for ReconnectSettings {
     fn default() -> Self {
         Self {
-            attempts: 100,
+            attempts: 0,
             duration: Duration::from_secs(1),
             duration_max: Duration::from_secs(30),
             backoff_factor: 1.5,

--- a/src/controller/handler/ha_connection.rs
+++ b/src/controller/handler/ha_connection.rs
@@ -107,7 +107,9 @@ impl Handler<ConnectMsg> for Controller {
                         // TODO quick and dirty: simply send Connect message as simple reconnect mechanism. Needs to be refined!
                         if act.device_state != DeviceState::Disconnected {
                             act.ha_reconnect_attempt += 1;
-                            if act.ha_reconnect_attempt > act.settings.hass.reconnect.attempts {
+                            if act.settings.hass.reconnect.attempts > 0
+                                && act.ha_reconnect_attempt > act.settings.hass.reconnect.attempts
+                            {
                                 info!(
                                     "Max reconnect attempts reached ({}). Giving up!",
                                     act.settings.hass.reconnect.attempts

--- a/src/controller/handler/setup.rs
+++ b/src/controller/handler/setup.rs
@@ -212,13 +212,13 @@ impl Handler<RequestExpertOptionsMsg> for Controller {
                             {
                                 "id": "reconnect.attempts",
                                 "label": {
-                                    "en": "Max reconnect attempts"
+                                    "en": "Max reconnect attempts (0 = unlimited)"
                                 },
                                 "field": {
                                     "number": {
                                         "value": self.settings.hass.reconnect.attempts,
-                                        "min": 1,
-                                        "max": 65536
+                                        "min": 0,
+                                        "max": 2000000
                                     }
                                 }
                             },

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -96,7 +96,7 @@ pub struct Controller {
     /// HomeAssistant client actor
     ha_client: Option<Addr<HomeAssistantClient>>,
     ha_reconnect_duration: Duration,
-    ha_reconnect_attempt: u16,
+    ha_reconnect_attempt: u32,
     drv_metadata: IntegrationDriverUpdate,
     /// State machine for driver state: setup flow or running state
     machine: StateMachine<OperationMode>,


### PR DESCRIPTION
A reconnect attempt value of 0 now means unlimited reconnection attempts without giving up.
This is also the new default, instead of just 100 attempts.

Fixes #34