### PR TITLE
refactor: use HA API ping pong messages instead of ping frames

### DIFF
--- a/src/client/entity/light.rs
+++ b/src/client/entity/light.rs
@@ -65,7 +65,7 @@ pub(crate) fn map_light_attributes(
                         ));
                     }
                     // hs values are returned as floats: hue: 0..360, saturation: 0..100
-                    let hue = hs.get(0).unwrap().as_f64().unwrap_or_default() as u16;
+                    let hue = hs.first().unwrap().as_f64().unwrap_or_default() as u16;
                     let saturation =
                         (hs.get(1).unwrap().as_f64().unwrap_or_default() as f32 * 2.55_f32) as u16;
                     if hue > 360 || saturation > 100 {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -158,6 +158,9 @@ impl Default for ReconnectSettings {
 #[serde_as]
 #[derive(Clone, Copy, serde::Deserialize, serde::Serialize)]
 pub struct HeartbeatSettings {
+    /// Use native WebSocket ping frames instead of [API messages](https://developers.home-assistant.io/docs/api/websocket/#pings-and-pongs)
+    #[serde(default)]
+    pub ping_frames: bool,
     /// How often heartbeat pings are sent
     #[serde_as(as = "DurationSeconds")]
     #[serde(rename = "interval_sec")]
@@ -171,6 +174,7 @@ pub struct HeartbeatSettings {
 impl Default for HeartbeatSettings {
     fn default() -> Self {
         Self {
+            ping_frames: false,
             interval: Duration::from_secs(20),
             timeout: Duration::from_secs(40),
         }
@@ -181,8 +185,8 @@ impl Display for HeartbeatSettings {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Heartbeat interval={:?}, timeout={:?}",
-            self.interval, self.timeout
+            "Heartbeat interval={:?}, timeout={:?}, ping frames={}",
+            self.interval, self.timeout, self.ping_frames
         )
     }
 }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -102,6 +102,8 @@ pub struct Controller {
     machine: StateMachine<OperationMode>,
     /// Driver setup timeout handle
     setup_timeout: Option<SpawnHandle>,
+    /// Handle to a scheduled connect message for a reconnect attempt.
+    reconnect_handle: Option<SpawnHandle>,
 }
 
 impl Controller {
@@ -127,6 +129,7 @@ impl Controller {
             drv_metadata,
             machine,
             setup_timeout: None,
+            reconnect_handle: None,
         }
     }
 


### PR DESCRIPTION
Use Ping-Pong API messages as defined in the HA WebSocket API https://developers.home-assistant.io/docs/api/websocket/#pings-and-pongs by default instead of WebSocket ping frames.

To further troubleshoot connection issues:
- Allow to disable heartbeat with setting the interval=0
- Allow to disable WebSocket disconnection in case of heartbeat timeout
- Log HA server version in connection log message
- Log response message text if authentication failed
- Cancel any pending reconnect message before connecting or disconnecting the HA client

Relates to unfoldedcircle/feature-and-bug-tracker#243