### PR TITLE
fix: reconnect to HA server after driver reconfiguration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,21 +2213,21 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2463,8 +2463,8 @@ dependencies = [
 
 [[package]]
 name = "uc_api"
-version = "0.8.1-alpha"
-source = "git+https://github.com/unfoldedcircle/api-model-rs?tag=v0.8.1-alpha#54fc74160cbbbc8f424097a9a2d3d6669cbb643c"
+version = "0.8.4-beta"
+source = "git+https://github.com/unfoldedcircle/api-model-rs?tag=v0.8.4-beta#ccef4d147fe1bce087aaaa955ff18c22a1a76a8f"
 dependencies = [
  "chrono",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ mdns-sd = ["dep:mdns-sd"]
 zeroconf = ["dep:zeroconf"]
 
 [dependencies]
-uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.8.1-alpha" }
+uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.8.4-beta" }
 # for local development:
 #uc_api = { path = "../api-model-rs" }
 
@@ -60,8 +60,8 @@ time = { version = "0.3", default-features = false, features = ["std", "formatti
 
 # Helpful macros for working with enums and strings
 # Attention: strum needs to be in sync with uc_api
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.25"
+strum_macros = "0.25"
 derive_more = "0.99"
 
 [build-dependencies]

--- a/resources/driver.json
+++ b/resources/driver.json
@@ -32,9 +32,9 @@
         "field": {
           "label": {
             "value": {
-              "en": "The driver requires WebSocket API access to communicate with Home Assistant.\nSee [Home Assistant documentation](https://www.home-assistant.io/docs/authentication/) for more information on how to create a long lived access token.",
-              "de": "Der Treiber benötigt WebSocket-API Zugriff, um mit Home Assistant zu kommunizieren.\nWeitere Informationen zur Erstellung eines langlebigen Zugriffstokens findest du in der [Home Assistant Dokumentation](https://www.home-assistant.io/docs/authentication/)",
-              "fr": "Le pilote nécessite l'accès à l'API WebSocket pour communiquer avec Home Assistant.\nVoir [Home Assistant documentation] (https://www.home-assistant.io/docs/authentication/) pour plus d'informations sur la création d'un \"long lived access token\"."
+              "en": "The driver requires WebSocket API access to communicate with Home Assistant.\nSee [Home Assistant documentation](https://www.home-assistant.io/docs/authentication/) for more information on how to create a long lived access token.\n\nThe access token is required for setting up the integration. If the integration is reconfigured, the access token can be omitted and the previously configured token is used.",
+              "de": "Der Treiber benötigt WebSocket-API Zugriff, um mit Home Assistant zu kommunizieren.\nWeitere Informationen zur Erstellung eines langlebigen Zugriffstokens findest du in der [Home Assistant Dokumentation](https://www.home-assistant.io/docs/authentication/).\n\nDas Zugriffstoken wird zum Einrichten der Integration benötigt. Wird die Integration neu konfiguriert, kann das Zugriffstoken weggelassen werden und das vorher konfigurierte Token wird verwendet.",
+              "fr": "Le pilote nécessite l'accès à l'API WebSocket pour communiquer avec Home Assistant.\nVoir [Home Assistant documentation] (https://www.home-assistant.io/docs/authentication/) pour plus d'informations sur la création d'un \"long lived access token\".\n\nLe token d'accès est requis pour configurer l'intégration. Si l'intégration est reconfigurée, le token d'accès peut être omis et le token précédemment configuré est utilisé."
             }
           }
         }
@@ -53,8 +53,8 @@
       {
         "id": "token",
         "label": {
-          "en": "Long lived access token",
-          "de": "Langlebiges Zugriffstoken"
+          "en": "Long lived access token (empty: old token)",
+          "de": "Langlebiges Zugriffstoken (leer: altes Token)"
         },
         "field": {
           "password": {

--- a/src/client/get_states.rs
+++ b/src/client/get_states.rs
@@ -6,7 +6,7 @@
 use std::str::FromStr;
 
 use actix::Handler;
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use serde_json::{json, Value};
 use uc_api::EntityType;
 
@@ -101,7 +101,7 @@ impl HomeAssistantClient {
                 EntityType::Sensor => convert_sensor_entity(entity_id, state, attr),
                 // internal core entities for the moment
                 EntityType::Activity | EntityType::Macro | EntityType::Remote => {
-                    warn!("[{}] skipping internal entity {entity_type}", self.id);
+                    info!("[{}] skipping internal entity {entity_type}", self.id);
                     continue;
                 }
             };

--- a/src/controller/handler/mod.rs
+++ b/src/controller/handler/mod.rs
@@ -27,7 +27,7 @@ struct SubscribeHaEventsMsg(pub R2RequestMsg);
 struct UnsubscribeHaEventsMsg(pub R2RequestMsg);
 
 /// Internal message to connect to Home Assistant.
-#[derive(Message)]
+#[derive(Message, Default)]
 #[rtype(result = "Result<(), std::io::Error>")]
 struct ConnectMsg {
     // device identifier for multi-HA connections: feature not yet available

--- a/src/controller/handler/r2_event.rs
+++ b/src/controller/handler/r2_event.rs
@@ -24,19 +24,12 @@ impl Handler<R2EventMsg> for Controller {
 
         match msg.event {
             R2Event::Connect => {
-                session.ha_connect = true;
-
                 if self.device_state != DeviceState::Connected {
-                    self.device_state = DeviceState::Connecting;
-                    self.send_device_state(&msg.ws_id);
-                    ctx.notify(ConnectMsg {});
+                    ctx.notify(ConnectMsg::default());
                 }
             }
             R2Event::Disconnect => {
-                session.ha_connect = false;
                 ctx.notify(DisconnectMsg {});
-                // this prevents automatic reconnects
-                self.set_device_state(DeviceState::Disconnected);
             }
             R2Event::EnterStandby => {
                 session.standby = true;

--- a/src/controller/handler/r2_request.rs
+++ b/src/controller/handler/r2_request.rs
@@ -45,8 +45,8 @@ impl Handler<R2RequestMsg> for Controller {
                 req_id,
                 resp_msg,
                 IntegrationVersion {
-                    api: API_VERSION.to_string(),
-                    integration: APP_VERSION.to_string(),
+                    api: Some(API_VERSION.to_string()),
+                    integration: Some(APP_VERSION.to_string()),
                 },
             )),
             R2Request::GetDriverMetadata => {


### PR DESCRIPTION
If the driver is reconfigured, disconnect and connect again with the new
connection settings.
Closes #36

Further improvements:
- Patch up reconnection logic to (hopefully) prevent multiple client
  connections.
- More log information to track down multiple connections.
- Use a unique connection id for each new HA client connection (counter
  suffix).

Relates to #39
Relates to unfoldedcircle/feature-and-bug-tracker#243