### PR TITLE
fix: send device_state event after connect request

### DIFF
--- a/src/controller/handler/r2_event.rs
+++ b/src/controller/handler/r2_event.rs
@@ -27,6 +27,8 @@ impl Handler<R2EventMsg> for Controller {
                 if self.device_state != DeviceState::Connected {
                     ctx.notify(ConnectMsg::default());
                 }
+                // make sure client has the correct state, it might be out of sync, or not calling get_device_state
+                self.send_device_state(&msg.ws_id);
             }
             R2Event::Disconnect => {
                 ctx.notify(DisconnectMsg {});

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -145,7 +145,7 @@ impl Controller {
                 return;
             }
             if let Err(e) = session.recipient.try_send(SendWsMessage(message)) {
-                error!("{ws_id} Internal message send error: {e}");
+                error!("[{ws_id}] Internal message send error: {e}");
             }
         } else {
             warn!("attempting to send message but couldn't find session: {ws_id}");
@@ -160,6 +160,7 @@ impl Controller {
     ///
     /// returns: ()
     fn send_device_state(&self, ws_id: &str) {
+        info!("[{ws_id}] sending device_state: {}", self.device_state);
         self.send_r2_msg(
             WsMessage::event(
                 "device_state",

--- a/src/server/ws/events.rs
+++ b/src/server/ws/events.rs
@@ -8,7 +8,7 @@ use crate::errors::ServiceError;
 use crate::server::ws::WsConn;
 use crate::Controller;
 use actix::Addr;
-use log::{debug, error, warn};
+use log::{error, info, warn};
 use std::str::FromStr;
 use uc_api::intg::ws::R2Event;
 use uc_api::ws::WsMessage;
@@ -25,7 +25,7 @@ impl WsConn {
             .as_deref()
             .ok_or_else(|| ServiceError::BadRequest("Missing property: msg".into()))?;
 
-        debug!("[{session_id}] Got event: {msg}");
+        info!("[{session_id}] Got event: {msg}");
 
         if let Ok(req_msg) = R2Event::from_str(msg) {
             if let Err(e) = controller_addr.try_send(R2EventMsg {


### PR DESCRIPTION
Sending the device_state event after receiving the connect event ensures that the remote remains in sync with the current integration state.

Log all received events from the remote with info level, since debug level is filtered out on the remote.

Fixes #43