### PR TITLE
Fix TCP connection timeout configuration 

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -110,8 +110,15 @@ pub struct WebSocketSettings {
 pub struct HomeAssistantSettings {
     pub url: Url,
     pub token: String,
-    /// WebSocket connection timeout in seconds
+    /// WebSocket connection timeout in seconds.
+    /// This is the max time allowed to connect to the remote host, including DNS name resolution.
+    /// Make sure that `request_timeout` >= `connection_timeout`.
     pub connection_timeout: u8,
+    /// WebSocket request timeout in seconds.
+    /// This is the total time before a response must be received. Should be equal or greater than `connection_timeout`.
+    // simplifies data migration: missing value in existing configuration will be set with a default!
+    #[serde(default = "default_request_timeout")]
+    pub request_timeout: u8,
     pub max_frame_size_kb: usize,
     pub reconnect: ReconnectSettings,
     pub heartbeat: HeartbeatSettings,
@@ -122,12 +129,17 @@ impl Default for HomeAssistantSettings {
         Self {
             url: Url::parse("ws://homeassistant.local:8123/api/websocket").unwrap(),
             token: "".to_string(),
-            connection_timeout: 3,
+            connection_timeout: 6,
+            request_timeout: default_request_timeout(),
             max_frame_size_kb: 5120,
             reconnect: Default::default(),
             heartbeat: Default::default(),
         }
     }
+}
+
+fn default_request_timeout() -> u8 {
+    6
 }
 
 #[serde_as]

--- a/src/controller/handler/ha_connection.rs
+++ b/src/controller/handler/ha_connection.rs
@@ -112,8 +112,9 @@ impl Handler<ConnectMsg> for Controller {
         let heartbeat = self.settings.hass.heartbeat;
 
         info!(
-            "Connecting to: {url} (timeout: {}s)",
-            self.settings.hass.connection_timeout
+            "Connecting to: {url} (timeout: {}s, request_timeout: {}s)",
+            self.settings.hass.connection_timeout,
+            self.settings.hass.request_timeout
         );
         Box::pin(
             async move {

--- a/src/controller/handler/ha_connection.rs
+++ b/src/controller/handler/ha_connection.rs
@@ -113,8 +113,7 @@ impl Handler<ConnectMsg> for Controller {
 
         info!(
             "Connecting to: {url} (timeout: {}s, request_timeout: {}s)",
-            self.settings.hass.connection_timeout,
-            self.settings.hass.request_timeout
+            self.settings.hass.connection_timeout, self.settings.hass.request_timeout
         );
         Box::pin(
             async move {

--- a/src/controller/handler/setup.rs
+++ b/src/controller/handler/setup.rs
@@ -134,6 +134,11 @@ impl Handler<SetDriverUserDataMsg> for Controller {
                     cfg.connection_timeout = value;
                 }
             }
+            if let Some(value) = parse_value(&values, "request_timeout") {
+                if value >= 3 {
+                    cfg.request_timeout = value;
+                }
+            }
             if let Some(value) = parse_value(&values, "max_frame_size_kb") {
                 if value >= 1024 {
                     cfg.max_frame_size_kb = value;
@@ -207,8 +212,8 @@ impl Handler<RequestExpertOptionsMsg> for Controller {
                             {
                                 "id": "connection_timeout",
                                 "label": {
-                                    "en": "Connection timeout in seconds",
-                                    "de": "Verbindungstimeout in Sekunden"
+                                    "en": "TCP connection timeout in seconds",
+                                    "de": "TCP Verbindungs-Timeout in Sekunden"
                                 },
                                 "field": {
                                     "number": {
@@ -216,6 +221,21 @@ impl Handler<RequestExpertOptionsMsg> for Controller {
                                         "min": 3,
                                         "max": 30,
                                         "unit": { "en": "sec" } // not yet working in web-configurator
+                                    }
+                                }
+                            },
+                            {
+                                "id": "request_timeout",
+                                "label": {
+                                    "en": "Request timeout in seconds",
+                                    "de": "Anfrage-Timeout in Sekunden"
+                                },
+                                "field": {
+                                    "number": {
+                                        "value": self.settings.hass.request_timeout,
+                                        "min": 3,
+                                        "max": 30,
+                                        "unit": { "en": "sec" }
                                     }
                                 }
                             },

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -122,6 +122,7 @@ impl Controller {
             device_state: DeviceState::Disconnected,
             ws_client: new_websocket_client(
                 Duration::from_secs(settings.hass.connection_timeout as u64),
+                Duration::from_secs(settings.hass.request_timeout as u64),
                 matches!(settings.hass.url.scheme(), "wss" | "https"),
             ),
             ha_reconnect_duration: settings.hass.reconnect.duration,

--- a/src/util/color.rs
+++ b/src/util/color.rs
@@ -92,9 +92,9 @@ pub fn color_xy_brightness_to_rgb(
 
 /// Convert an rgb color to its hsv representation.
 ///
-///     Hue is scaled 0-360
-///     Sat is scaled 0-100
-///     Val is scaled 0-100
+/// - Hue is scaled 0-360
+/// - Sat is scaled 0-100
+/// - Val is scaled 0-100
 pub fn color_rgb_to_hsv(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
     let (h, s, v) = rgb_to_hsv(r / 255.0, g / 255.0, b / 255.0);
     (round(h * 360., 3), round(s * 100., 3), round(v * 100., 3))


### PR DESCRIPTION
The connection timeout is now only used for the TCP connection timeout.
Add dedicated request timeout for the overall request timeout.
Default timeout is increased to 6 seconds due to user reports of connection timeouts.

Fixes #47