### PR TITLE
Home Assistant WebSocket API connection tool

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ rustflags = "-C target-cpu=cortex-a55"
 [target.arm-unknown-linux-gnueabihf]
 linker = "yio-arm-buildroot-linux-gnueabihf-gcc"
 rustflags = "-C target-cpu=arm1176jzf-s"
+
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         run: cargo clippy --features mdns-sd -- -D warnings
 
   build:
-    name: Build release
+    name: Linux-x64 build
     needs: test
     runs-on: ubuntu-22.04
     steps:
@@ -229,10 +229,85 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
+  tools:
+    name: ${{ matrix.config.name }} build
+    runs-on: ${{ matrix.config.os }}
+    needs: test
+    strategy:
+      matrix:
+        config:
+          - {
+            name: "ha-test Linux-x64",
+            target: "Linux-x64",
+            os: "ubuntu-latest",
+            artifact: "ha-test",
+            archive: "ha-test_Linux-x64.tar.gz"
+            }
+          - {
+            name: "ha-test Windows-x64",
+            target: "Windows-x64",
+            os: "windows-latest",
+            artifact: "ha-test.exe",
+            archive: "ha-test_Windows-x64.zip"
+            }
+          - {
+            name: "ha-test macOS-x64",
+            target: "macOS-x64",
+            os: "macos-latest",
+            artifact: "ha-test",
+            archive: "ha-test_macOS-x64.tar.gz"
+            }
+
+    steps:
+      - name: Checkout ${{ env.PROJECT_NAME}}
+        uses: actions/checkout@v4
+
+      - id: setup
+        uses: ./.github/actions/rust-setup
+        with:
+          build: release
+          use_gh_cache: ${{ env.USE_GH_CACHE }}
+          incremental: ${{ env.INCREMENTAL_BUILD }} && !contains(github.ref, 'tags/v')
+
+      - name: Release build
+        run: cargo build --release --bin ha-test
+
+      # Archive is required to preserve file permissions
+      - name: Prepare upload artifact
+        shell: bash
+        run: |
+          ls -la target/release
+          mkdir -p ${{env.BIN_OUTPUT_PATH }}
+          cp target/release/${{ matrix.config.artifact }} ${{ env.BIN_OUTPUT_PATH }}
+          cp resources/home-assistant.json ${{ env.BIN_OUTPUT_PATH }}
+          ls -la ${{ env.BIN_OUTPUT_PATH }}
+
+      - name: Create zip upload artifact for Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cd ${{ env.BIN_OUTPUT_PATH }}
+          7z a -tzip ../target/release/${{ matrix.config.archive }} *
+
+      - name: Create tar.gz upload artifact
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          tar czvf target/release/${{ matrix.config.archive }} -C ${{ env.BIN_OUTPUT_PATH }} .
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        id: upload_artifact
+        with:
+          name: ha-test-${{ matrix.config.target }}
+          path: target/release/${{ matrix.config.archive }}
+          if-no-files-found: error
+          retention-days: 3
+
   release:
     name: GitHub release
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'tags/v')
-    needs: [build, cross_compile]
+    needs: [build, cross_compile, tools]
     runs-on: ubuntu-22.04
 
     steps:
@@ -253,7 +328,7 @@ jobs:
         run: |
           echo "TIMESTAMP=$(date +"%Y%m%d_%H%M%S")" >> $GITHUB_ENV
 
-      - name: Extract tar.gz build archives from downloaded artifacts
+      - name: Extract archives from downloaded artifacts
         run: |
           # Files are wrapped in tar from actions/upload-artifact, then extracted into a directory by actions/download-artifact
           ls -lah
@@ -272,8 +347,9 @@ jobs:
         run: |
           echo "append timestamp for development builds"
           for filename in *.tar.gz; do mv $filename "$(basename $filename .tar.gz)-${{ env.TIMESTAMP }}.tar.gz"; done;
+          for filename in *.zip; do mv $filename "$(basename $filename .zip)-${{ env.TIMESTAMP }}.zip"; done;
           echo "create hashes"
-          for filename in *.tar.gz; do echo "sha256  `sha256sum $filename`" >> ${{ env.HASH_FILENAME }}; done;
+          for filename in *.{tar.gz,zip}; do echo "sha256  `sha256sum $filename`" >> ${{ env.HASH_FILENAME }}; done;
           ls -lah
 
       - name: Create Pre-Release
@@ -286,13 +362,14 @@ jobs:
           title: "Development Build"
           files: |
             *.tar.gz
+            *.zip
             ${{ env.HASH_FILENAME }}
 
       - name: Create GitHub release archives
         if: "contains(github.ref, 'tags/v')"
         run: |
           echo "create hashes"
-          for filename in *.tar.gz; do echo "sha256  `sha256sum $filename`" >> ${{ env.HASH_FILENAME }}; done;
+          for filename in *.{tar.gz,zip}; do echo "sha256  `sha256sum $filename`" >> ${{ env.HASH_FILENAME }}; done;
           ls -lah
 
       - name: Create Release
@@ -303,6 +380,7 @@ jobs:
           prerelease: false
           files: |
             *.tar.gz
+            *.zip
             ${{ env.HASH_FILENAME }}
 
   container:
@@ -312,7 +390,7 @@ jobs:
     needs: release
 
     steps:
-      - name: Download build artifacts
+      - name: Download Linux-x64 build artifact
         uses: actions/download-artifact@v4
         with:
           pattern: "uc-intg-hass-*-${{ env.LINUX_ARTIFACT_SUFFIX }}*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           use_gh_cache: ${{ env.USE_GH_CACHE }}
           incremental: ${{ env.INCREMENTAL_BUILD }}
 
-      - run: cargo test --features mdns-sd
+      - run: cargo test --features mdns-sd --bin uc-intg-hass
 
       - name: Run clippy
         run: cargo clippy --features mdns-sd -- -D warnings
@@ -315,7 +315,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "*-${{ env.LINUX_ARTIFACT_SUFFIX }}*"
+          pattern: "uc-intg-hass-*-${{ env.LINUX_ARTIFACT_SUFFIX }}*"
 
       - name: Log
         if: env.DEBUG_OUTPUT == 'true'

--- a/.idea/runConfigurations/Run_ha_test.xml
+++ b/.idea/runConfigurations/Run_ha_test.xml
@@ -1,9 +1,9 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="All Tests" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
-    <option name="command" value="test --bin uc-intg-hass" />
+  <configuration default="false" name="Run ha-test" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="command" value="run --bin ha-test" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
     <envs />
-    <option name="emulateTerminal" value="false" />
+    <option name="emulateTerminal" value="true" />
     <option name="channel" value="DEFAULT" />
     <option name="requiredFeatures" value="true" />
     <option name="allFeatures" value="false" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,15 +374,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anyhow"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "autocfg"
@@ -652,27 +647,30 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
  "strsim 0.10.0",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -1215,15 +1213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,12 +1604,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking_lot"
@@ -2240,21 +2223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "time"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2378,7 @@ dependencies = [
  "actix-tls",
  "actix-web",
  "actix-web-actors",
+ "anyhow",
  "awc",
  "built",
  "bytes",
@@ -2665,15 +2634,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,21 @@ authors = ["Markus Zehnder <markus.z@unfoldedcircle.com>"]
 license = "MPL-2.0"
 description = "Unfolded Circle Home-Assistant integration for Remote Two"
 repository = "https://github.com/unfoldedcircle/integration-home-assistant"
+default-run = "uc-intg-hass"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "uc-intg-hass"
+path = "src/main.rs"
+
+[[bin]]
+name = "ha-test"
+path = "src/bin/ha_test.rs"
 
 [features]
 default = []
@@ -48,7 +60,7 @@ serde_with = "3"
 
 rust-fsm = "0.6"
 
-clap = "3"
+clap = "4"
 config = { version = "0.14", default-features = false, features = ["yaml", "json"] }
 const_format = "0.2"
 env_logger = "0.11"
@@ -64,6 +76,8 @@ time = { version = "0.3", default-features = false, features = ["std", "formatti
 strum = "0.25"
 strum_macros = "0.25"
 derive_more = "0.99"
+
+anyhow = { version = "1", features = [] }
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2", "chrono", "dependency-tree", "semver"] }

--- a/resources/README.md
+++ b/resources/README.md
@@ -7,3 +7,9 @@
 - `version` property value is overwritten at runtime with application version.
 - `token` value is removed if set.
 - `driver_id` and `name` are automatically set if missing.
+
+## home-assistant.json
+
+Template configuration file for the [src/bin/ha_test.rs](../src/bin/ha_test.rs) tool.
+
+This is the same configuration file format written by the integration during the setup flow.

--- a/resources/home-assistant.json
+++ b/resources/home-assistant.json
@@ -1,0 +1,20 @@
+{
+  "hass": {
+    "url": "ws://homeassistant.local:8123/api/websocket",
+    "token": "",
+    "connection_timeout": 6,
+    "request_timeout": 6,
+    "max_frame_size_kb": 5120,
+    "reconnect": {
+      "attempts": 0,
+      "duration_ms": 300,
+      "duration_max_ms": 30000,
+      "backoff_factor": 1.5
+    },
+    "heartbeat": {
+      "ping_frames": false,
+      "interval_sec": 5,
+      "timeout_sec": 20
+    }
+  }
+}

--- a/src/bin/ha_test.rs
+++ b/src/bin/ha_test.rs
@@ -1,0 +1,176 @@
+// Copyright (c) 2024 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
+// SPDX-License-Identifier: MPL-2.0
+
+//! Home-Assistant WebSocket API connection test tool
+
+use actix::{Actor, Addr, Context, Handler};
+use actix_web::rt::time::sleep;
+use clap::{Arg, Command};
+use log::{debug, error, info};
+use std::env;
+use std::str::FromStr;
+use std::time::Duration;
+use uc_api::intg::ws::{R2Event, R2Request};
+use uc_intg_hass::configuration::{get_configuration, Settings, DEF_HA_URL, ENV_HASS_MSG_TRACING};
+use uc_intg_hass::{
+    configuration, Controller, NewR2Session, R2EventMsg, R2RequestMsg, SendWsMessage, APP_VERSION,
+};
+use url::Url;
+
+#[actix_web::main]
+async fn main() -> anyhow::Result<()> {
+    let cfg = parse_args_load_cfg()?;
+
+    let driver_metadata = configuration::get_driver_metadata()?;
+    let controller = Controller::new(cfg, driver_metadata.clone()).start();
+
+    // Mock server to simulate an R2 connection
+    let ws_id = "HA-test".to_string();
+    let server = ServerMock::new(&ws_id, controller.clone()).start();
+
+    // establish a mock session
+    controller
+        .send(NewR2Session {
+            addr: server.recipient(),
+            id: ws_id.clone(),
+        })
+        .await?;
+
+    // connect to HA
+    controller
+        .send(R2EventMsg {
+            ws_id: ws_id.clone(),
+            event: R2Event::Connect,
+            msg_data: None,
+        })
+        .await?;
+
+    // quick and dirty for now
+    sleep(Duration::from_secs(30)).await;
+
+    Ok(())
+}
+
+fn parse_args_load_cfg() -> anyhow::Result<Settings> {
+    let args = Command::new("ha-test")
+        .author("Unfolded Circle ApS")
+        .version(APP_VERSION)
+        .about("Home Assistant server communication test")
+        .arg(
+            Arg::new("url")
+                .short('u')
+                .default_value(DEF_HA_URL)
+                .help("Home Assistant WebSocket API URL (overrides home-assistant.json)"),
+        )
+        .arg(
+            Arg::new("token")
+                .short('t')
+                .help("Home Assistant long lived access token (overrides home-assistant.json)"),
+        )
+        .arg(
+            Arg::new("connection_timeout")
+                .short('c')
+                .help("TCP connection timeout in seconds (overrides home-assistant.json)"),
+        )
+        .arg(
+            Arg::new("request_timeout")
+                .short('r')
+                .help("Request timeout in seconds (overrides home-assistant.json)"),
+        )
+        .arg(
+            Arg::new("trace_level")
+                .long("trace")
+                .value_name("MESSAGES")
+                .value_parser(["in", "out", "all", "none"])
+                .default_value("all")
+                .help("Message tracing for HA server communication"),
+        )
+        .get_matches();
+
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
+    if let Some(msg_trace) = args.get_one::<String>("trace_level") {
+        env::set_var(ENV_HASS_MSG_TRACING, msg_trace);
+    }
+    let cfg_file = None;
+    let mut cfg = get_configuration(cfg_file).expect("Failed to read configuration");
+    if let Some(url) = args.get_one::<String>("url") {
+        cfg.hass.url = Url::parse(url)?;
+    }
+    if let Some(token) = args.get_one::<String>("token") {
+        cfg.hass.token = token.clone();
+    }
+    if let Some(timeout) = args.get_one::<String>("connection_timeout") {
+        cfg.hass.connection_timeout = u8::from_str(timeout)?;
+    }
+    if let Some(timeout) = args.get_one::<String>("request_timeout") {
+        cfg.hass.request_timeout = u8::from_str(timeout)?;
+    }
+
+    if !cfg.hass.url.has_host() || cfg.hass.token.is_empty() {
+        eprintln!("Can't connect to Home Assistant: URL or token is missing");
+        std::process::exit(1);
+    }
+
+    Ok(cfg)
+}
+
+struct ServerMock {
+    id: String,
+    connected: bool,
+    controller_addr: Addr<Controller>,
+}
+
+impl ServerMock {
+    fn new(id: impl Into<String>, controller_addr: Addr<Controller>) -> Self {
+        Self {
+            id: id.into(),
+            connected: false,
+            controller_addr,
+        }
+    }
+}
+impl Actor for ServerMock {
+    type Context = Context<Self>;
+}
+
+impl Handler<SendWsMessage> for ServerMock {
+    type Result = ();
+
+    fn handle(&mut self, msg: SendWsMessage, _ctx: &mut Self::Context) {
+        let msg_name = msg.0.msg.clone().unwrap_or_default();
+        if msg_name == "device_state" {
+            if let Some(msg_data) = msg.0.msg_data.as_ref() {
+                self.connected = msg_data
+                    .as_object()
+                    .and_then(|o| o.get("state"))
+                    .and_then(|s| s.as_str())
+                    == Some("CONNECTED");
+
+                if self.connected {
+                    self.controller_addr.do_send(R2RequestMsg {
+                        ws_id: self.id.clone(),
+                        req_id: 0,
+                        request: R2Request::GetEntityStates,
+                        msg_data: None,
+                    });
+                }
+            }
+        }
+
+        if let Ok(msg) = serde_json::to_string(&msg.0) {
+            if msg_name == "entity_states" {
+                info!("[{}] <- entity_states:\n{msg}", self.id);
+                self.controller_addr.do_send(R2EventMsg {
+                    ws_id: self.id.clone(),
+                    event: R2Event::Disconnect,
+                    msg_data: None,
+                });
+                info!("Entity states received, disconnecting!");
+            } else {
+                debug!("[{}] <- {msg}", self.id);
+            }
+        } else {
+            error!("[{}] Error serializing {:?}", self.id, msg.0)
+        }
+    }
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -4,7 +4,7 @@
 //! Configuration file handling.
 
 use crate::errors::ServiceError;
-use crate::{APP_VERSION, DRIVER_METADATA};
+use crate::APP_VERSION;
 use config::Config;
 use log::{error, info, warn};
 use serde_with::{serde_as, DurationMilliSeconds, DurationSeconds};
@@ -15,6 +15,11 @@ use std::time::Duration;
 use std::{env, fs, io};
 use uc_api::intg::IntegrationDriverUpdate;
 use url::Url;
+
+/// Default configuration file.
+pub const DEF_CONFIG_FILE: &str = "configuration.yaml";
+
+pub const DEF_HA_URL: &str = "ws://homeassistant.local:8123/api/websocket";
 
 pub const ENV_SETUP_TIMEOUT: &str = "UC_SETUP_TIMEOUT";
 pub const DEF_SETUP_TIMEOUT_SEC: u64 = 300;
@@ -54,6 +59,9 @@ pub const ENV_API_MSG_TRACING: &str = "UC_API_MSG_TRACING";
 
 /// Environment variable to disable TLS verification to the Home Assistant server.
 pub const ENV_DISABLE_CERT_VERIFICATION: &str = "UC_DISABLE_CERT_VERIFICATION";
+
+/// Compiled-in driver metadata in json format.
+const DRIVER_METADATA: &str = include_str!("../resources/driver.json");
 
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 pub struct Settings {
@@ -127,7 +135,7 @@ pub struct HomeAssistantSettings {
 impl Default for HomeAssistantSettings {
     fn default() -> Self {
         Self {
-            url: Url::parse("ws://homeassistant.local:8123/api/websocket").unwrap(),
+            url: Url::parse(DEF_HA_URL).unwrap(),
             token: "".to_string(),
             connection_timeout: 6,
             request_timeout: default_request_timeout(),

--- a/src/controller/handler/r2_request.rs
+++ b/src/controller/handler/r2_request.rs
@@ -3,6 +3,7 @@
 
 //! Actix message handler for [R2RequestMsg].
 
+use crate::built_info;
 use crate::client::messages::{CallService, GetStates};
 use crate::controller::handler::{
     SetDriverUserDataMsg, SetupDriverMsg, SubscribeHaEventsMsg, UnsubscribeHaEventsMsg,
@@ -10,14 +11,24 @@ use crate::controller::handler::{
 use crate::controller::{Controller, OperationModeInput, R2RequestMsg};
 use crate::errors::ServiceError;
 use crate::util::{return_fut_err, return_fut_ok, DeserializeMsgData};
-use crate::{API_VERSION, APP_VERSION};
+use crate::APP_VERSION;
 use actix::{fut, AsyncContext, Handler, ResponseFuture};
+use lazy_static::lazy_static;
 use log::{debug, error};
 use serde_json::{json, Value};
 use strum::EnumMessage;
 use uc_api::intg::ws::R2Request;
 use uc_api::intg::{EntityCommand, IntegrationVersion};
 use uc_api::ws::{EventCategory, WsMessage, WsResultMsgData};
+
+lazy_static! {
+    /// Integration-API version.
+    pub static ref API_VERSION: &'static str = built_info::DEPENDENCIES
+        .iter()
+        .find(|p| p.0 == "uc_api")
+        .map(|v| v.1)
+        .unwrap_or("?");
+}
 
 impl Handler<R2RequestMsg> for Controller {
     type Result = ResponseFuture<Result<Option<WsMessage>, ServiceError>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
+// SPDX-License-Identifier: MPL-2.0
+
+pub mod client;
+pub mod controller;
+pub mod server;
+pub mod util;
+
+pub mod configuration;
+pub mod errors;
+pub mod startup;
+
+pub use controller::*;
+pub use startup::*;

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
+// SPDX-License-Identifier: MPL-2.0
+
+use const_format::formatcp;
+
+/// Build information like timestamp, git hash, etc.
+pub mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+/// Application version built from git version information.
+pub const APP_VERSION: &str = formatcp!(
+    "{}{}",
+    match built_info::GIT_VERSION {
+        Some(v) => v,
+        None => formatcp!("{}-non-git", built_info::PKG_VERSION),
+    },
+    match built_info::GIT_DIRTY {
+        Some(_) => "-dirty",
+        None => "",
+    }
+);


### PR DESCRIPTION
The `bin/ha_test.rs` tool is a simple CLI tool to test the Home Assistant WebSocket API connectivity with the exact same code & logic as the HA integration for Remote Two.

The main purpose of this tool is to troubleshoot connectivity issues from a PC. X64 binaries for Linux, macOS and Windows are automatically built with a GitHub action.

### Functionality

1. Connect to the HA server and authenticate with the token
2. Subscribe to entity state events: `subscribe_events`
3. Request the entity states: `get_states`
4. Disconnect

### Required parameters

- HA long lived access token.
- HA WebSocket URL. Default if not provided: `ws://homeassistant.local:8123/api/websocket`

The configuration can either be provided in a `home-assistant.json` file in the current directory (see ./resources directory for a template), or through command line parameters.


### Usage

```
/ha-test --help
Home Assistant server communication test

Usage: ha-test [OPTIONS]

Options:
  -u <url>                     Home Assistant WebSocket API URL (overrides home-assistant.json) [default: ws://homeassistant.local:8123/api/websocket]
  -t <token>                   Home Assistant long lived access token (overrides home-assistant.json)
  -c <connection_timeout>      TCP connection timeout in seconds (overrides home-assistant.json)
  -r <request_timeout>         Request timeout in seconds (overrides home-assistant.json)
      --trace <MESSAGES>       Message tracing for HA server communication [default: all] [possible values: in, out, all, none]
  -h, --help                   Print help
  -V, --version                Print version
```