### PR TITLE
Support remote-entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- Remote-entity support ([#23](https://github.com/unfoldedcircle/integration-home-assistant/issues/23)).
+
 ---
 
 ## v0.8.2 - 2024-03-04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "uc_api"
 version = "0.9.3-beta"
-source = "git+https://github.com/unfoldedcircle/api-model-rs?rev=af6697550c4d05ab5fcb2734d6c9e126415eec79#af6697550c4d05ab5fcb2734d6c9e126415eec79"
+source = "git+https://github.com/unfoldedcircle/api-model-rs?rev=2424dc4cef1025b681c7db221ad39baea260ce8c#2424dc4cef1025b681c7db221ad39baea260ce8c"
 dependencies = [
  "chrono",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,8 +2429,8 @@ dependencies = [
 
 [[package]]
 name = "uc_api"
-version = "0.9.3-beta"
-source = "git+https://github.com/unfoldedcircle/api-model-rs?rev=7b700c7dfff34b64a7e9e9101f2eb2226d61a35f#7b700c7dfff34b64a7e9e9101f2eb2226d61a35f"
+version = "0.10.0-beta"
+source = "git+https://github.com/unfoldedcircle/api-model-rs?tag=v0.10.0#9de37a922969ac326d373a1649ddc901e832713e"
 dependencies = [
  "chrono",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "uc_api"
 version = "0.9.3-beta"
-source = "git+https://github.com/unfoldedcircle/api-model-rs?rev=2424dc4cef1025b681c7db221ad39baea260ce8c#2424dc4cef1025b681c7db221ad39baea260ce8c"
+source = "git+https://github.com/unfoldedcircle/api-model-rs?rev=7b700c7dfff34b64a7e9e9101f2eb2226d61a35f#7b700c7dfff34b64a7e9e9101f2eb2226d61a35f"
 dependencies = [
  "chrono",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2430,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "uc_api"
 version = "0.9.3-beta"
-source = "git+https://github.com/unfoldedcircle/api-model-rs?tag=v0.9.3-beta#36b5766d4b56aff2213ebd57dd5f3877feed7e04"
+source = "git+https://github.com/unfoldedcircle/api-model-rs?rev=af6697550c4d05ab5fcb2734d6c9e126415eec79#af6697550c4d05ab5fcb2734d6c9e126415eec79"
 dependencies = [
  "chrono",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ mdns-sd = ["dep:mdns-sd"]
 zeroconf = ["dep:zeroconf"]
 
 [dependencies]
-#uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.9.3-beta" }
+uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.10.0" }
 # for local development:
 #uc_api = { path = "../api-model-rs" }
 # Using a GitHub revision:
-uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", rev = "7b700c7dfff34b64a7e9e9101f2eb2226d61a35f" }
+#uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", rev = "1650ada3e11bb90318cef173811b6c475fa1d782" }
 
 # WebSockets server
 actix-web = { version = "4.4", features = ["rustls-0_21"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,11 @@ mdns-sd = ["dep:mdns-sd"]
 zeroconf = ["dep:zeroconf"]
 
 [dependencies]
-uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.9.3-beta" }
+#uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.9.3-beta" }
 # for local development:
 #uc_api = { path = "../api-model-rs" }
+# Using a GitHub revision:
+uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", rev = "af6697550c4d05ab5fcb2734d6c9e126415eec79" }
 
 # WebSockets server
 actix-web = { version = "4.4", features = ["rustls-0_21"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ zeroconf = ["dep:zeroconf"]
 # for local development:
 #uc_api = { path = "../api-model-rs" }
 # Using a GitHub revision:
-uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", rev = "af6697550c4d05ab5fcb2734d6c9e126415eec79" }
+uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", rev = "2424dc4cef1025b681c7db221ad39baea260ce8c" }
 
 # WebSockets server
 actix-web = { version = "4.4", features = ["rustls-0_21"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ zeroconf = ["dep:zeroconf"]
 # for local development:
 #uc_api = { path = "../api-model-rs" }
 # Using a GitHub revision:
-uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", rev = "2424dc4cef1025b681c7db221ad39baea260ce8c" }
+uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", rev = "7b700c7dfff34b64a7e9e9101f2eb2226d61a35f" }
 
 # WebSockets server
 actix-web = { version = "4.4", features = ["rustls-0_21"] }

--- a/src/client/entity/climate.rs
+++ b/src/client/entity/climate.rs
@@ -11,7 +11,7 @@ use log::warn;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use uc_api::intg::{AvailableIntgEntity, EntityChange};
-use uc_api::{ClimateFeature, ClimateOption, EntityType};
+use uc_api::{ClimateFeature, ClimateOptionField, EntityType};
 
 // https://developers.home-assistant.io/docs/core/entity/climate#supported-features
 pub const SUPPORT_TARGET_TEMPERATURE: u32 = 1;
@@ -129,17 +129,17 @@ pub(crate) fn convert_climate_entity(
     // handle options. TODO untested! Only based on some GitHub issue logs :-) #12
     let mut options = serde_json::Map::new();
     if let Some(v) = number_value(ha_attr, "min_temp") {
-        options.insert(ClimateOption::MinTemperature.to_string(), v);
+        options.insert(ClimateOptionField::MinTemperature.to_string(), v);
     }
     if let Some(v) = number_value(ha_attr, "max_temp") {
-        options.insert(ClimateOption::MaxTemperature.to_string(), v);
+        options.insert(ClimateOptionField::MaxTemperature.to_string(), v);
     }
     if let Some(v) = number_value(ha_attr, "target_temp_step") {
-        options.insert(ClimateOption::TargetTemperatureStep.to_string(), v);
+        options.insert(ClimateOptionField::TargetTemperatureStep.to_string(), v);
     }
     // TODO how do we get the HA temperature_unit attribute? Couldn't find an example... #10
     if let Some(v) = ha_attr.get("temperature_unit") {
-        options.insert(ClimateOption::TemperatureUnit.to_string(), v.clone());
+        options.insert(ClimateOptionField::TemperatureUnit.to_string(), v.clone());
     }
 
     // convert attributes

--- a/src/client/entity/mod.rs
+++ b/src/client/entity/mod.rs
@@ -8,6 +8,7 @@ mod climate;
 mod cover;
 mod light;
 mod media_player;
+mod remote;
 mod sensor;
 mod switch;
 
@@ -16,5 +17,6 @@ pub(crate) use climate::*;
 pub(crate) use cover::*;
 pub(crate) use light::*;
 pub(crate) use media_player::*;
+pub(crate) use remote::*;
 pub(crate) use sensor::*;
 pub(crate) use switch::*;

--- a/src/client/entity/remote.rs
+++ b/src/client/entity/remote.rs
@@ -8,8 +8,8 @@ use crate::client::model::EventData;
 use crate::errors::ServiceError;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
-use uc_api::intg::{AvailableIntgEntity, EntityChange};
-use uc_api::{EntityType, RemoteFeature};
+use uc_api::intg::{AvailableIntgEntity, EntityChange, IntgRemoteFeature};
+use uc_api::EntityType;
 
 pub(crate) fn remote_event_to_entity_change(
     mut data: EventData,
@@ -45,9 +45,9 @@ pub(crate) fn convert_remote_entity(
         name,
         // toggle, on and off seem to be fixed features in HA
         features: Some(vec![
-            RemoteFeature::Send.to_string(),
-            RemoteFeature::OnOff.to_string(),
-            RemoteFeature::Toggle.to_string(),
+            IntgRemoteFeature::SendCmd.to_string(),
+            IntgRemoteFeature::OnOff.to_string(),
+            IntgRemoteFeature::Toggle.to_string(),
         ]),
         area: None,
         // Available commands are not retrievable from HA :-(

--- a/src/client/entity/remote.rs
+++ b/src/client/entity/remote.rs
@@ -1,0 +1,196 @@
+// Copyright (c) 2024 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
+// SPDX-License-Identifier: MPL-2.0
+
+//! Remote entity specific logic.
+
+use crate::client::event::convert_ha_onoff_state;
+use crate::client::model::EventData;
+use crate::errors::ServiceError;
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+use uc_api::intg::{AvailableIntgEntity, EntityChange};
+use uc_api::{EntityType, RemoteFeature};
+
+pub(crate) fn remote_event_to_entity_change(
+    mut data: EventData,
+) -> Result<EntityChange, ServiceError> {
+    let attributes = map_remote_attributes(
+        &data.entity_id,
+        &data.new_state.state,
+        data.new_state.attributes.as_mut(),
+    )?;
+
+    Ok(EntityChange {
+        device_id: None,
+        entity_type: EntityType::Remote,
+        entity_id: data.entity_id,
+        attributes,
+    })
+}
+
+pub(crate) fn convert_remote_entity(
+    entity_id: String,
+    state: String,
+    ha_attr: &mut Map<String, Value>,
+) -> Result<AvailableIntgEntity, ServiceError> {
+    let friendly_name = ha_attr.get("friendly_name").and_then(|v| v.as_str());
+    let name = HashMap::from([("en".into(), friendly_name.unwrap_or(&entity_id).into())]);
+    let attributes = Some(map_remote_attributes(&entity_id, &state, Some(ha_attr))?);
+
+    Ok(AvailableIntgEntity {
+        entity_id,
+        device_id: None, // prepared device_id handling
+        entity_type: EntityType::Remote,
+        device_class: None,
+        name,
+        // toggle, on and off seem to be fixed features in HA
+        features: Some(vec![
+            RemoteFeature::Send.to_string(),
+            RemoteFeature::OnOff.to_string(),
+            RemoteFeature::Toggle.to_string(),
+        ]),
+        area: None,
+        // Available commands are not retrievable from HA :-(
+        // Feature proposition: https://github.com/home-assistant/architecture/discussions/875
+        options: None,
+        attributes,
+    })
+}
+
+fn map_remote_attributes(
+    _entity_id: &str,
+    state: &str,
+    _ha_attr: Option<&mut Map<String, Value>>,
+) -> Result<Map<String, Value>, ServiceError> {
+    let mut attributes = serde_json::Map::with_capacity(1);
+    let state = convert_ha_onoff_state(state)?;
+
+    attributes.insert("state".into(), state);
+
+    Ok(attributes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::model::Event;
+    use serde_json::json;
+    use uc_api::EntityType;
+
+    #[test]
+    fn convert_ha_entity() {
+        let mut ha_entity = json!({
+          "entity_id": "remote.office_tv",
+          "state": "on",
+          "attributes": {
+            "activity_list": null,
+            "current_activity": "com.google.android.apps.tv.dreamx",
+            "friendly_name": "Office TV",
+            "supported_features": 4
+          },
+          "last_changed": "2024-04-04T19:24:45.412493+00:00",
+          "last_updated": "2024-04-04T19:34:47.438673+00:00",
+          "context": {
+            "id": "01HTN9PJCE9WJHGKC5ZMAGVHBB",
+            "parent_id": null,
+            "user_id": null
+          }
+        });
+        let ha_entity = ha_entity.as_object_mut().unwrap();
+
+        let entity_id = ha_entity
+            .get("entity_id")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let state = ha_entity
+            .get("state")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let attr = ha_entity
+            .get_mut("attributes")
+            .and_then(|v| v.as_object_mut())
+            .unwrap();
+
+        let result = convert_remote_entity(entity_id, state, attr);
+        assert!(
+            result.is_ok(),
+            "Expected successful entity conversion but got: {:?}",
+            result.unwrap_err()
+        );
+        let entity = result.unwrap();
+
+        assert_eq!("remote.office_tv", entity.entity_id);
+        assert_eq!(EntityType::Remote, entity.entity_type);
+        assert!(entity.features.is_some(), "Expected entity features");
+        assert!(entity.attributes.is_some(), "Expected entity attributes");
+        let attr = entity.attributes.unwrap();
+        assert_eq!(1, attr.len());
+        assert_eq!(Some(&json!("ON")), attr.get("state"));
+    }
+
+    #[test]
+    fn remote_event_on() {
+        let event = json!({
+          "event_type": "state_changed",
+          "data": {
+            "entity_id": "remote.office_tv",
+            "old_state": {
+              "entity_id": "remote.office_tv",
+              "state": "off",
+              "attributes": {
+                "activity_list": null,
+                "current_activity": "com.google.android.apps.tv.launcherx",
+                "friendly_name": "Office TV",
+                "supported_features": 4
+              },
+              "last_changed": "2024-04-04T15:27:32.086304+00:00",
+              "last_updated": "2024-04-04T19:24:44.282594+00:00",
+              "context": {
+                "id": "01HTN944487A1J7QMGBWYWS7P8",
+                "parent_id": null,
+                "user_id": "08f6dc9d675e49ce8454a647e8216e4d"
+              }
+            },
+            "new_state": {
+              "entity_id": "remote.office_tv",
+              "state": "on",
+              "attributes": {
+                "activity_list": null,
+                "current_activity": "com.google.android.apps.tv.launcherx",
+                "friendly_name": "Office TV",
+                "supported_features": 4
+              },
+              "last_changed": "2024-04-04T19:24:45.412493+00:00",
+              "last_updated": "2024-04-04T19:24:45.412493+00:00",
+              "context": {
+                "id": "01HTN944487A1J7QMGBWYWS7P8",
+                "parent_id": null,
+                "user_id": "08f6dc9d675e49ce8454a647e8216e4d"
+              }
+            }
+          },
+          "origin": "LOCAL",
+          "time_fired": "2024-04-04T19:24:45.412493+00:00",
+          "context": {
+            "id": "01HTN944487A1J7QMGBWYWS7P8",
+            "parent_id": null,
+            "user_id": "08f6dc9d675e49ce8454a647e8216e4d"
+          }
+        });
+
+        let event = serde_json::from_value::<Event>(event).unwrap();
+        let result = remote_event_to_entity_change(event.data);
+        assert!(
+            result.is_ok(),
+            "Expected successful event mapping but got: {:?}",
+            result.unwrap_err()
+        );
+        let entity_change = result.unwrap();
+        assert_eq!("remote.office_tv", entity_change.entity_id);
+        assert_eq!(EntityType::Remote, entity_change.entity_type);
+        assert_eq!(1, entity_change.attributes.len());
+        assert_eq!(Some(&json!("ON")), entity_change.attributes.get("state"));
+    }
+}

--- a/src/client/entity/sensor.rs
+++ b/src/client/entity/sensor.rs
@@ -9,7 +9,7 @@ use crate::errors::ServiceError;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use uc_api::intg::AvailableIntgEntity;
-use uc_api::{intg::EntityChange, EntityType, SensorOption};
+use uc_api::{intg::EntityChange, EntityType, SensorOptionField};
 
 pub(crate) fn map_sensor_attributes(
     _entity_id: &str,
@@ -82,11 +82,14 @@ pub(crate) fn convert_sensor_entity(
         v => {
             if let Some(v) = v {
                 if let Some(label) = device_class_to_label(v) {
-                    options.insert(SensorOption::CustomLabel.to_string(), Value::String(label));
+                    options.insert(
+                        SensorOptionField::CustomLabel.to_string(),
+                        Value::String(label),
+                    );
                 }
             }
             if let Some(v) = ha_attr.get("unit_of_measurement") {
-                options.insert(SensorOption::CustomUnit.to_string(), v.clone());
+                options.insert(SensorOptionField::CustomUnit.to_string(), v.clone());
             }
             Some("custom".into())
         }

--- a/src/client/event.rs
+++ b/src/client/event.rs
@@ -51,6 +51,7 @@ impl HomeAssistantClient {
             "binary_sensor" => binary_sensor_event_to_entity_change(event.data),
             "climate" => climate_event_to_entity_change(event.data),
             "media_player" => media_player_event_to_entity_change(&self.server, event.data),
+            "remote" => remote_event_to_entity_change(event.data),
             &_ => {
                 debug!("[{}] Unsupported entity: {}", self.id, entity_type);
                 return Ok(()); // it's not really an error, so it's ok ;-)

--- a/src/client/get_states.rs
+++ b/src/client/get_states.rs
@@ -98,9 +98,10 @@ impl HomeAssistantClient {
                 EntityType::MediaPlayer => {
                     convert_media_player_entity(&self.server, entity_id, state, attr)
                 }
+                EntityType::Remote => convert_remote_entity(entity_id, state, attr),
                 EntityType::Sensor => convert_sensor_entity(entity_id, state, attr),
                 // internal core entities for the moment
-                EntityType::Activity | EntityType::Macro | EntityType::Remote => {
+                EntityType::Activity | EntityType::Macro => {
                     info!("[{}] skipping internal entity {entity_type}", self.id);
                     continue;
                 }

--- a/src/client/service/mod.rs
+++ b/src/client/service/mod.rs
@@ -22,6 +22,7 @@ mod climate;
 mod cover;
 mod light;
 mod media_player;
+mod remote;
 mod switch;
 
 impl Handler<CallService> for HomeAssistantClient {
@@ -46,15 +47,14 @@ impl Handler<CallService> for HomeAssistantClient {
             EntityType::Cover => cover::handle_cover(&msg.command),
             EntityType::Light => light::handle_light(&msg.command),
             EntityType::MediaPlayer => media_player::handle_media_player(&msg.command),
+            EntityType::Remote => remote::handle_remote(&msg.command),
             EntityType::Sensor => Err(ServiceError::BadRequest(
                 "Sensor doesn't support sending commands to! Ignoring call".to_string(),
             )),
-            EntityType::Activity | EntityType::Macro | EntityType::Remote => {
-                Err(ServiceError::BadRequest(format!(
-                    "{} is an internal remote-core entity",
-                    msg.command.entity_type
-                )))
-            }
+            EntityType::Activity | EntityType::Macro => Err(ServiceError::BadRequest(format!(
+                "{} is an internal remote-core entity",
+                msg.command.entity_type
+            ))),
         }?;
         info!(
             "[{}] Calling {} service '{service}'",

--- a/src/client/service/remote.rs
+++ b/src/client/service/remote.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
+// SPDX-License-Identifier: MPL-2.0
+
+//! Remote entity specific HA service call logic.
+
+use crate::client::service::{cmd_from_str, get_required_params};
+use crate::errors::ServiceError;
+use serde_json::{Map, Value};
+use uc_api::intg::EntityCommand;
+use uc_api::RemoteCommand;
+
+pub(crate) fn handle_remote(msg: &EntityCommand) -> Result<(String, Option<Value>), ServiceError> {
+    let cmd: RemoteCommand = cmd_from_str(&msg.cmd_id)?;
+
+    let result = match cmd {
+        RemoteCommand::On => ("turn_on".into(), None),
+        RemoteCommand::Off => ("turn_off".into(), None),
+        RemoteCommand::Toggle => ("toggle".into(), None),
+        RemoteCommand::Send => create_command(msg, "command")?,
+        RemoteCommand::SendSequence => create_command(msg, "sequence")?,
+        RemoteCommand::StopSend => return Err(ServiceError::NotYetImplemented),
+    };
+
+    Ok(result)
+}
+
+fn create_command(msg: &EntityCommand, cmd: &str) -> Result<(String, Option<Value>), ServiceError> {
+    let mut data = Map::new();
+    let params = get_required_params(msg)?;
+    if let Some(value) = params.get(cmd) {
+        if cmd == "sequence" && value.is_array() || cmd == "command" && value.is_string() {
+            data.insert("command".into(), value.clone());
+        }
+    }
+    if data.is_empty() {
+        return Err(ServiceError::BadRequest(format!(
+            "Invalid or missing attribute: params.{}",
+            cmd
+        )));
+    }
+    if let Some(value) = params.get("repeat").and_then(|v| v.as_u64()) {
+        data.insert("num_repeats".into(), value.into());
+    }
+    if let Some(value) = params
+        .get("delay")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as f32 / 1000f32)
+    {
+        data.insert("delay_secs".into(), value.into());
+    }
+    if let Some(value) = params
+        .get("hold")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as f32 / 1000f32)
+    {
+        data.insert("hold_secs".into(), value.into());
+    }
+    Ok(("send_command".into(), Some(data.into())))
+}

--- a/src/client/service/remote.rs
+++ b/src/client/service/remote.rs
@@ -6,19 +6,17 @@
 use crate::client::service::{cmd_from_str, get_required_params};
 use crate::errors::ServiceError;
 use serde_json::{Map, Value};
-use uc_api::intg::EntityCommand;
-use uc_api::RemoteCommand;
+use uc_api::intg::{EntityCommand, IntgRemoteCommand};
 
 pub(crate) fn handle_remote(msg: &EntityCommand) -> Result<(String, Option<Value>), ServiceError> {
-    let cmd: RemoteCommand = cmd_from_str(&msg.cmd_id)?;
+    let cmd: IntgRemoteCommand = cmd_from_str(&msg.cmd_id)?;
 
     let result = match cmd {
-        RemoteCommand::On => ("turn_on".into(), None),
-        RemoteCommand::Off => ("turn_off".into(), None),
-        RemoteCommand::Toggle => ("toggle".into(), None),
-        RemoteCommand::Send => create_command(msg, "command")?,
-        RemoteCommand::SendSequence => create_command(msg, "sequence")?,
-        RemoteCommand::StopSend => return Err(ServiceError::NotYetImplemented),
+        IntgRemoteCommand::On => ("turn_on".into(), None),
+        IntgRemoteCommand::Off => ("turn_off".into(), None),
+        IntgRemoteCommand::Toggle => ("toggle".into(), None),
+        IntgRemoteCommand::SendCmd => create_command(msg, "command")?,
+        IntgRemoteCommand::SendCmdSequence => create_command(msg, "sequence")?,
     };
 
     Ok(result)


### PR DESCRIPTION
Support [Home Assistant Remote Entity](https://developers.home-assistant.io/docs/core/entity/remote/) with the addition of remote-entity in the Integration-API (https://github.com/unfoldedcircle/core-api/pull/44).

- Single command or command sequence.
- Supports optional `num_repeats`, `delay_secs` and `hold_secs` command parameters.

Requires remote-core / Simulator version 0.43.0, which will be released soon.

Not supported Home Assistant Remote Entity features:
- Learn & delete command
- Activities: list of available activities and current active activity

Closes #23