### PR TITLE
Automatic configuration and setup through the UC Home Assistant component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- Automatic configuration and setup through the [Unfolded Circle for Home Assistant component](https://github.com/JackJPowell/hass-unfoldedcircle). In cooperation with @albaintor and @JackJPowell, thanks! ([#60](https://github.com/unfoldedcircle/integration-home-assistant/pull/60)).  
+  - Please note that the autoconfiguration feature in the Home Assistant component is still under development. 
+### Fixed
+- Avoid initial failed Home Assistant login attempt with default HA server url and empty access token.
 
 ---
 
 ## v0.10.0 - 2024-08-24
 ### Added
-- Initial support for the UC unified integration in Home Assistant for optimized message communication. Contributed by @albaintor, thanks! ([#58](https://github.com/unfoldedcircle/integration-home-assistant/pull/58))
+- Initial support for the [Unfolded Circle for Home Assistant component](https://github.com/JackJPowell/hass-unfoldedcircle) for optimized message communication. Contributed by @albaintor, thanks! ([#58](https://github.com/unfoldedcircle/integration-home-assistant/pull/58))
 
 ### Changed
 - Update uc_api crate to latest 0.12.0 version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,8 +2497,8 @@ dependencies = [
 
 [[package]]
 name = "uc_api"
-version = "0.12.0"
-source = "git+https://github.com/unfoldedcircle/api-model-rs?tag=v0.12.0#c4320688be2ef56cc9f0fa200ae974ea1a63b37d"
+version = "0.12.1"
+source = "git+https://github.com/unfoldedcircle/api-model-rs?tag=v0.12.1#3fa2749f6fc3a86bd5c104a907af8e3f9ed31f97"
 dependencies = [
  "chrono",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ mdns-sd = ["dep:mdns-sd"]
 zeroconf = ["dep:zeroconf"]
 
 [dependencies]
-uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.12.0" }
+uc_api = { git = "https://github.com/unfoldedcircle/api-model-rs", tag = "v0.12.1" }
 # for local development:
 #uc_api = { path = "../api-model-rs" }
 # Using a GitHub revision:

--- a/resources/driver.json
+++ b/resources/driver.json
@@ -1,5 +1,11 @@
 {
   "driver_id": "hass",
+  "features": [
+    {
+      "name": "auth.external_tokens",
+      "required": false
+    }
+  ],
   "version": "",
   "min_core_api": "0.20.0",
   "name": {
@@ -34,7 +40,7 @@
             "value": {
               "en": "The driver requires WebSocket API access to communicate with Home Assistant.\nSee [Home Assistant documentation](https://www.home-assistant.io/docs/authentication/) for more information on how to create a long lived access token.\n\nWhen using the [Unfolded Circle for Home Assistant component](https://github.com/JackJPowell/hass-unfoldedcircle), the connection parameters are automatically configured and you don't need to manually set an access token.\n\nThe _enhanced options_ below can be used to change expert connection parameters.",
               "de": "Der Treiber benötigt WebSocket-API Zugriff, um mit Home Assistant zu kommunizieren.\nWeitere Informationen zur Erstellung eines langlebigen Zugriffstokens findest du in der [Home Assistant Dokumentation](https://www.home-assistant.io/docs/authentication/).\n\nWenn Du die [Unfolded Circle for Home Assistant](https://github.com/JackJPowell/hass-unfoldedcircle) Komponente verwendest, werden die Verbindungsparameter automatisch konfiguriert, und Du musst kein Zugriffstoken manuell setzen.\n\nMit den _erweiterten Optionen_ können Experten-Verbindungsparameter geändert werden.",
-              "fr": "Le pilote nécessite l'accès à l'API WebSocket pour communiquer avec Home Assistant.\nVoir [Home Assistant documentation] (https://www.home-assistant.io/docs/authentication/) pour plus d'informations sur la création d'un \"long lived access token\".\n\nLorsque vous utilisez le composant [Unfolded Circle for Home Assistant](https://github.com/JackJPowell/hass-unfoldedcircle), les paramètres de connexion sont automatiquement configurés et vous n'avez pas besoin de définir manuellement un jeton d'accès.\n\nLes _options avancées_ ci-dessous peuvent être utilisées pour modifier les paramètres de connexion des experts."
+              "fr": "Le pilote nécessite l'accès à l'API WebSocket pour communiquer avec Home Assistant.\nVoir [Home Assistant documentation](https://www.home-assistant.io/docs/authentication/) pour plus d'informations sur la création d'un \"long lived access token\".\n\nLorsque vous utilisez le composant [Unfolded Circle for Home Assistant](https://github.com/JackJPowell/hass-unfoldedcircle), les paramètres de connexion sont automatiquement configurés et vous n'avez pas besoin de définir manuellement un jeton d'accès.\n\nLes _options avancées_ ci-dessous peuvent être utilisées pour modifier les paramètres de connexion des experts."
             }
           }
         }

--- a/resources/driver.json
+++ b/resources/driver.json
@@ -32,32 +32,10 @@
         "field": {
           "label": {
             "value": {
-              "en": "The driver requires WebSocket API access to communicate with Home Assistant.\nSee [Home Assistant documentation](https://www.home-assistant.io/docs/authentication/) for more information on how to create a long lived access token.\n\nThe access token is required for setting up the integration. If the integration is reconfigured, the access token can be omitted and the previously configured token is used.",
-              "de": "Der Treiber benötigt WebSocket-API Zugriff, um mit Home Assistant zu kommunizieren.\nWeitere Informationen zur Erstellung eines langlebigen Zugriffstokens findest du in der [Home Assistant Dokumentation](https://www.home-assistant.io/docs/authentication/).\n\nDas Zugriffstoken wird zum Einrichten der Integration benötigt. Wird die Integration neu konfiguriert, kann das Zugriffstoken weggelassen werden und das vorher konfigurierte Token wird verwendet.",
-              "fr": "Le pilote nécessite l'accès à l'API WebSocket pour communiquer avec Home Assistant.\nVoir [Home Assistant documentation] (https://www.home-assistant.io/docs/authentication/) pour plus d'informations sur la création d'un \"long lived access token\".\n\nLe token d'accès est requis pour configurer l'intégration. Si l'intégration est reconfigurée, le token d'accès peut être omis et le token précédemment configuré est utilisé."
+              "en": "The driver requires WebSocket API access to communicate with Home Assistant.\nSee [Home Assistant documentation](https://www.home-assistant.io/docs/authentication/) for more information on how to create a long lived access token.\n\nWhen using the [Unfolded Circle for Home Assistant component](https://github.com/JackJPowell/hass-unfoldedcircle), the connection parameters are automatically configured and you don't need to manually set an access token.\n\nThe _enhanced options_ below can be used to change expert connection parameters.",
+              "de": "Der Treiber benötigt WebSocket-API Zugriff, um mit Home Assistant zu kommunizieren.\nWeitere Informationen zur Erstellung eines langlebigen Zugriffstokens findest du in der [Home Assistant Dokumentation](https://www.home-assistant.io/docs/authentication/).\n\nWenn Du die [Unfolded Circle for Home Assistant](https://github.com/JackJPowell/hass-unfoldedcircle) Komponente verwendest, werden die Verbindungsparameter automatisch konfiguriert, und Du musst kein Zugriffstoken manuell setzen.\n\nMit den _erweiterten Optionen_ können Experten-Verbindungsparameter geändert werden.",
+              "fr": "Le pilote nécessite l'accès à l'API WebSocket pour communiquer avec Home Assistant.\nVoir [Home Assistant documentation] (https://www.home-assistant.io/docs/authentication/) pour plus d'informations sur la création d'un \"long lived access token\".\n\nLorsque vous utilisez le composant [Unfolded Circle for Home Assistant](https://github.com/JackJPowell/hass-unfoldedcircle), les paramètres de connexion sont automatiquement configurés et vous n'avez pas besoin de définir manuellement un jeton d'accès.\n\nLes _options avancées_ ci-dessous peuvent être utilisées pour modifier les paramètres de connexion des experts."
             }
-          }
-        }
-      },
-      {
-        "id": "url",
-        "label": {
-          "en": "WebSocket API URL"
-        },
-        "field": {
-          "text": {
-            "value": "ws://homeassistant.local:8123/api/websocket"
-          }
-        }
-      },
-      {
-        "id": "token",
-        "label": {
-          "en": "Long lived access token (empty: old token)",
-          "de": "Langlebiges Zugriffstoken (leer: altes Token)"
-        },
-        "field": {
-          "password": {
           }
         }
       },
@@ -76,5 +54,5 @@
       }
     ]
   },
-  "release_date": "2023-03-08"
+  "release_date": "2023-08-27"
 }

--- a/src/bin/ha_test.rs
+++ b/src/bin/ha_test.rs
@@ -94,10 +94,10 @@ fn parse_args_load_cfg() -> anyhow::Result<Settings> {
     let cfg_file = None;
     let mut cfg = get_configuration(cfg_file).expect("Failed to read configuration");
     if let Some(url) = args.get_one::<String>("url") {
-        cfg.hass.url = Url::parse(url)?;
+        cfg.hass.set_url(Url::parse(url)?);
     }
     if let Some(token) = args.get_one::<String>("token") {
-        cfg.hass.token = token.clone();
+        cfg.hass.set_token(token);
     }
     if let Some(timeout) = args.get_one::<String>("connection_timeout") {
         cfg.hass.connection_timeout = u8::from_str(timeout)?;
@@ -106,7 +106,7 @@ fn parse_args_load_cfg() -> anyhow::Result<Settings> {
         cfg.hass.request_timeout = u8::from_str(timeout)?;
     }
 
-    if !cfg.hass.url.has_host() || cfg.hass.token.is_empty() {
+    if !cfg.hass.get_url().has_host() || cfg.hass.get_token().is_empty() {
         eprintln!("Can't connect to Home Assistant: URL or token is missing");
         std::process::exit(1);
     }

--- a/src/client/get_states.rs
+++ b/src/client/get_states.rs
@@ -19,7 +19,7 @@ impl Handler<GetStates> for HomeAssistantClient {
     type Result = Result<(), ServiceError>;
 
     fn handle(&mut self, msg: GetStates, ctx: &mut Self::Context) -> Self::Result {
-        debug!("[{}] GetStates from {}", self.id, msg.remote_id);
+        debug!("[{}] GetStates from '{}'", self.id, msg.remote_id);
         self.remote_id = msg.remote_id;
         let entity_ids = msg.entity_ids;
         let id = self.new_msg_id();

--- a/src/client/messages.rs
+++ b/src/client/messages.rs
@@ -84,6 +84,13 @@ pub struct EntityEvent {
     pub entity_change: EntityChange,
 }
 
+/// Set remote id from remote to client
+#[derive(Message)]
+#[rtype(result = "Result<(), ServiceError>")]
+pub struct SetRemoteId {
+    pub remote_id: String,
+}
+
 /// HA client request: disconnect and close the session.
 // Used internally by the client and from Controller
 #[derive(Message)]

--- a/src/client/set_remote_id.rs
+++ b/src/client/set_remote_id.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 Unfolded Circle ApS, Markus Zehnder <markus.z@unfoldedcircle.com>
+// SPDX-License-Identifier: MPL-2.0
+
+//! Actix actor handler implementation for the `SetRemoteId` message
+
+use crate::client::messages::SetRemoteId;
+use crate::client::HomeAssistantClient;
+use crate::errors::ServiceError;
+use actix::Handler;
+use log::debug;
+
+impl Handler<SetRemoteId> for HomeAssistantClient {
+    type Result = Result<(), ServiceError>;
+
+    fn handle(&mut self, msg: SetRemoteId, ctx: &mut Self::Context) -> Self::Result {
+        debug!("[{}] SetRemoteId from {}", self.id, msg.remote_id);
+        self.remote_id = msg.remote_id;
+        if self.uc_ha_component {
+            self.unsubscribe_uc_configuration(ctx);
+            self.subscribe_uc_configuration(ctx);
+        }
+        Ok(())
+    }
+}

--- a/src/client/set_remote_id.rs
+++ b/src/client/set_remote_id.rs
@@ -13,7 +13,7 @@ impl Handler<SetRemoteId> for HomeAssistantClient {
     type Result = Result<(), ServiceError>;
 
     fn handle(&mut self, msg: SetRemoteId, ctx: &mut Self::Context) -> Self::Result {
-        debug!("[{}] SetRemoteId from {}", self.id, msg.remote_id);
+        debug!("[{}] SetRemoteId: '{}'", self.id, msg.remote_id);
         self.remote_id = msg.remote_id;
         if self.uc_ha_component {
             self.unsubscribe_uc_configuration(ctx);

--- a/src/client/subscribed_entities.rs
+++ b/src/client/subscribed_entities.rs
@@ -18,8 +18,9 @@ impl Handler<SubscribedEntities> for HomeAssistantClient {
         if !self.authenticated {
             return;
         }
-        // Occurs when the remote reloads due (wakes up) or when the user
+        // Occurs when the remote reloads (wakes up) or when the user
         // selected new entities from HA, subscribe to configuration event if not already done
+        self.unsubscribe_uc_configuration(_ctx);
         self.subscribe_uc_configuration(_ctx);
         self.unsubscribe_uc_events(_ctx);
         self.subscribe_uc_events(_ctx);

--- a/src/client/subscribed_entities.rs
+++ b/src/client/subscribed_entities.rs
@@ -9,7 +9,7 @@ impl Handler<SubscribedEntities> for HomeAssistantClient {
     /// Method called by controller when subscribed entities change
     /// The custom HA component has to be updated then (if used)
     /// msg contains the new entity ids to subscribe
-    fn handle(&mut self, msg: SubscribedEntities, _ctx: &mut Self::Context) {
+    fn handle(&mut self, msg: SubscribedEntities, ctx: &mut Self::Context) {
         debug!(
             "[{}] Updated subscribed entities: {:?}",
             self.id, msg.entity_ids
@@ -20,9 +20,9 @@ impl Handler<SubscribedEntities> for HomeAssistantClient {
         }
         // Occurs when the remote reloads (wakes up) or when the user
         // selected new entities from HA, subscribe to configuration event if not already done
-        self.unsubscribe_uc_configuration(_ctx);
-        self.subscribe_uc_configuration(_ctx);
-        self.unsubscribe_uc_events(_ctx);
-        self.subscribe_uc_events(_ctx);
+        self.unsubscribe_uc_configuration(ctx);
+        self.subscribe_uc_configuration(ctx);
+        self.unsubscribe_uc_events(ctx);
+        self.subscribe_uc_events(ctx);
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -32,6 +32,12 @@ const DEV_USER_CFG_FILENAME: &str = "home-assistant.json";
 /// This ENV variable is set on the Remote device to the integration specific data directory.
 const ENV_CONFIG_HOME: &str = "UC_CONFIG_HOME";
 
+/// Environment variable for the credential files directory.
+const ENV_TOKENS_HOME: &str = "UC_TOKENS_HOME";
+
+/// External system `token_id` value holding the HA server url and access token.
+const TOKEN_ID: &str = "ws-ha-api";
+
 /// Environment variable to disable mDNS service publishing.
 ///
 /// When running on the Remote device, service publishing is not required.
@@ -116,8 +122,8 @@ pub struct WebSocketSettings {
 
 #[derive(Clone, serde::Deserialize, serde::Serialize)]
 pub struct HomeAssistantSettings {
-    pub url: Url,
-    pub token: String,
+    url: Url,
+    token: String,
     /// WebSocket connection timeout in seconds.
     /// This is the max time allowed to connect to the remote host, including DNS name resolution.
     /// Make sure that `request_timeout` >= `connection_timeout`.
@@ -148,6 +154,78 @@ impl Default for HomeAssistantSettings {
             reconnect: Default::default(),
             heartbeat: Default::default(),
             disconnect_in_standby: default_disconnect_in_standby(),
+        }
+    }
+}
+
+impl HomeAssistantSettings {
+    /// Checks if an external URL and token has been provided.
+    ///
+    /// See Core-API: `/auth/external/:system`
+    pub fn has_external_url_and_token(&self) -> bool {
+        self.get_token_value(TOKEN_ID).is_some() && self.get_ext_url().is_some()
+    }
+
+    /// Return the configured HA server URL.
+    ///
+    /// This is either the provided URL in the external system, or the local configuration URL.
+    pub fn get_url(&self) -> Url {
+        if let Some(url) = self.get_ext_url() {
+            return url;
+        }
+        self.url.clone()
+    }
+
+    fn get_ext_url(&self) -> Option<Url> {
+        let key = format!("{TOKEN_ID}-URL");
+        if let Some(url) = self.get_token_value(&key) {
+            match Url::parse(&url) {
+                Ok(url) => return Some(url),
+                Err(e) => error!("Invalid URL in token '{key}': {e}"),
+            }
+        }
+        None
+    }
+
+    /// Return the configured HA server access token.
+    ///
+    /// This is either the provided token in the external system, or the local configuration token.
+    pub fn get_token(&self) -> String {
+        self.get_token_value(TOKEN_ID)
+            .unwrap_or_else(|| self.token.clone())
+    }
+
+    /// Update the local configuration URL.
+    pub fn set_url(&mut self, url: Url) {
+        self.url = url;
+    }
+
+    /// Update the local configuration token.
+    pub fn set_token(&mut self, token: impl ToString) {
+        self.token = token.to_string();
+    }
+
+    /// Get the value of an external system token key.
+    ///
+    /// # Arguments
+    ///
+    /// * `key`: token key
+    ///
+    /// returns: None if the token file doesn't exist or the file couldn't be read.
+    fn get_token_value(&self, key: &str) -> Option<String> {
+        let mut path = PathBuf::from(env::var(ENV_TOKENS_HOME).ok()?);
+        path.push(key);
+        if !path.is_file() {
+            warn!("Token file '{key}' does not exist. Using local configuration.");
+            return None;
+        }
+
+        match fs::read_to_string(path) {
+            Ok(v) => Some(v.trim().to_string()),
+            Err(e) => {
+                error!("Error reading token file '{key}', using local configuration. {e}");
+                None
+            }
         }
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -216,7 +216,7 @@ impl HomeAssistantSettings {
         let mut path = PathBuf::from(env::var(ENV_TOKENS_HOME).ok()?);
         path.push(key);
         if !path.is_file() {
-            warn!("Token file '{key}' does not exist. Using local configuration.");
+            info!("Token file '{key}' does not exist. Using local configuration.");
             return None;
         }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -201,8 +201,8 @@ impl HomeAssistantSettings {
     }
 
     /// Update the local configuration token.
-    pub fn set_token(&mut self, token: impl ToString) {
-        self.token = token.to_string();
+    pub fn set_token(&mut self, token: impl AsRef<str>) {
+        self.token = token.as_ref().trim().to_string();
     }
 
     /// Get the value of an external system token key.

--- a/src/controller/handler/ha_connection.rs
+++ b/src/controller/handler/ha_connection.rs
@@ -103,11 +103,11 @@ impl Handler<ConnectMsg> for Controller {
 
         self.set_device_state(DeviceState::Connecting);
 
-        let ws_request = self.ws_client.ws(self.settings.hass.url.as_str());
+        let url = self.settings.hass.get_url();
+        let ws_request = self.ws_client.ws(url.as_str());
         // align frame size to Home Assistant
         let ws_request = ws_request.max_frame_size(self.settings.hass.max_frame_size_kb * 1024);
-        let url = self.settings.hass.url.clone();
-        let token = self.settings.hass.token.clone();
+        let token = self.settings.hass.get_token();
         let client_address = ctx.address();
         let heartbeat = self.settings.hass.heartbeat;
 
@@ -137,7 +137,7 @@ impl Handler<ConnectMsg> for Controller {
                 act.ha_client_id = None; // will be set with Connected event
                 match result {
                     Ok(addr) => {
-                        debug!("Successfully connected to: {}", act.settings.hass.url);
+                        debug!("Successfully connected to: {}", act.settings.hass.get_url());
                         act.ha_client = Some(addr);
                         act.ha_reconnect_duration = act.settings.hass.reconnect.duration;
                         act.ha_reconnect_attempt = 0;

--- a/src/controller/handler/ha_connection.rs
+++ b/src/controller/handler/ha_connection.rs
@@ -143,7 +143,6 @@ impl Handler<ConnectMsg> for Controller {
                 act.ha_client_id = None; // will be set with Connected event
                 match result {
                     Ok(addr) => {
-                        debug!("Successfully connected to: {}", act.settings.hass.get_url());
                         act.ha_client = Some(addr);
                         act.ha_reconnect_duration = act.settings.hass.reconnect.duration;
                         act.ha_reconnect_attempt = 0;
@@ -152,16 +151,13 @@ impl Handler<ConnectMsg> for Controller {
                             let entities = session.subscribed_entities.clone();
                             if let Some(ha_client) = &act.ha_client {
                                 if let Err(e) = ha_client.try_send(SetRemoteId { remote_id }) {
-                                    error!("Error sending remote identifier to client : {:?}", e);
+                                    error!("Error sending remote identifier to client: {:?}", e);
                                 }
 
                                 if let Err(e) = ha_client.try_send(SubscribedEntities {
                                     entity_ids: entities,
                                 }) {
-                                    error!(
-                                        "Error updating subscribed entities to client : {:?}",
-                                        e
-                                    );
+                                    error!("Error updating subscribed entities to client: {:?}", e);
                                 }
                             }
                         }

--- a/src/controller/handler/r2_response.rs
+++ b/src/controller/handler/r2_response.rs
@@ -28,13 +28,13 @@ impl Handler<R2ResponseMsg> for Controller {
                     .get_mut("hostname")
                     .and_then(|v| v.as_str())
                 {
-                    info!("Remote identifier : {:?}", remote_id);
+                    info!("Remote identifier: '{remote_id}'");
                     self.remote_id = remote_id.to_string();
                     if let Some(ha_client) = &self.ha_client {
                         if let Err(e) = ha_client.try_send(SetRemoteId {
                             remote_id: self.remote_id.clone(),
                         }) {
-                            error!("Error sending remote identifier to client : {:?}", e);
+                            error!("Error sending remote identifier to client: {:?}", e);
                         }
                     }
                 }

--- a/src/controller/handler/r2_response.rs
+++ b/src/controller/handler/r2_response.rs
@@ -3,17 +3,48 @@
 
 //! Actix message handler for [R2ResponseMsg].
 
+use crate::client::messages::SetRemoteId;
 use crate::controller::{Controller, R2ResponseMsg};
 use actix::Handler;
-use log::info;
+use log::{error, info};
+use uc_api::intg::ws::R2Response;
 
 impl Handler<R2ResponseMsg> for Controller {
     type Result = ();
 
     fn handle(&mut self, msg: R2ResponseMsg, _ctx: &mut Self::Context) -> Self::Result {
-        info!(
-            "[{}] TODO implement remote response: {}",
-            msg.ws_id, msg.msg
-        );
+        match msg.msg {
+            R2Response::RuntimeInfo => {
+                info!("{:?}", msg);
+            }
+            R2Response::Version => {
+                info!("{:?}", msg);
+                if let Some(remote_id) = msg
+                    .response
+                    .msg_data
+                    .unwrap()
+                    .as_object_mut()
+                    .unwrap()
+                    .get_mut("hostname")
+                    .and_then(|v| v.as_str())
+                {
+                    info!("Remote identifier : {:?}", remote_id);
+                    self.remote_id = remote_id.to_string();
+                    if let Some(ha_client) = &self.ha_client {
+                        if let Err(e) = ha_client.try_send(SetRemoteId {
+                            remote_id: self.remote_id.clone(),
+                        }) {
+                            error!("Error sending remote identifier to client : {:?}", e);
+                        }
+                    }
+                }
+            }
+            _ => {
+                info!(
+                    "[{}] TODO implement remote response: {}",
+                    msg.ws_id, msg.msg
+                );
+            }
+        }
     }
 }

--- a/src/controller/handler/setup.rs
+++ b/src/controller/handler/setup.rs
@@ -25,6 +25,13 @@ use url::Url;
 /// Local Actix message to request further user data.
 #[derive(Constructor, Message)]
 #[rtype(result = "()")]
+struct RequestOptionsMsg {
+    pub ws_id: String,
+}
+
+/// Local Actix message to request further user data.
+#[derive(Constructor, Message)]
+#[rtype(result = "()")]
 struct RequestExpertOptionsMsg {
     pub ws_id: String,
 }
@@ -40,8 +47,8 @@ struct FinishSetupFlowMsg {
 /// Start integration setup flow.
 ///
 /// Disconnect an active HA connection to start a new client connection with the changed data later.   
-/// Either continue with expert configuration options with [RequestExpertOptionsMsg] if selected in initial
-/// configuration screen, or finish setup with [FinishSetupFlowMsg].
+/// Either continue the normal configuration with [RequestOptionsMsg], or the expert configuration
+/// options with [RequestExpertOptionsMsg] if selected in initial configuration screen.
 impl Handler<SetupDriverMsg> for Controller {
     type Result = Result<(), ServiceError>;
 
@@ -57,38 +64,12 @@ impl Handler<SetupDriverMsg> for Controller {
             ));
         }
 
-        let mut cfg = self.settings.hass.clone();
-
-        // validate setup data
-        cfg.url = validate_url(msg.data.setup_data.get("url").map(|u| u.as_str()))?;
-
-        if let Some(token) = msg.data.setup_data.get("token").map(|t| t.trim()) {
-            if token.is_empty() && !cfg.token.is_empty() {
-                warn!(
-                    "[{}] no token value provided in setup, using existing token",
-                    msg.ws_id
-                )
-            } else if !token.is_empty() {
-                cfg.token = token.to_string();
-            } else {
-                return Err(BadRequest("Missing token".into()));
-            }
-        } else {
-            return Err(BadRequest("Missing field: token".into()));
-        }
-
         if let Some(session) = self.sessions.get_mut(&msg.ws_id) {
             session.reconfiguring = msg.data.reconfigure;
         };
 
-        save_user_settings(&cfg)?;
-
         info!("Disconnecting from HA during setup-flow");
         self.disconnect(ctx);
-
-        // TODO verify WebSocket connection to make sure user provided URL & token are ok! #3
-        // Right now the core will just send a Connect request after setup...
-        self.settings.hass = cfg;
 
         // use a delay that the ack response will be sent first
         let delay = Duration::from_millis(100);
@@ -99,11 +80,10 @@ impl Handler<SetupDriverMsg> for Controller {
             .and_then(|v| bool::from_str(v).ok())
             .unwrap_or_default()
         {
-            // start expert setup with an additional configuration screen
+            // start expert setup with a different configuration screen
             ctx.notify_later(RequestExpertOptionsMsg::new(msg.ws_id), delay);
         } else {
-            // setup done!
-            ctx.notify_later(FinishSetupFlowMsg::new(msg.ws_id, None), delay);
+            ctx.notify_later(RequestOptionsMsg::new(msg.ws_id), delay);
         }
 
         // this will acknowledge the setup_driver request message
@@ -111,7 +91,7 @@ impl Handler<SetupDriverMsg> for Controller {
     }
 }
 
-/// Handle driver setup input data from the expert configuration screen.
+/// Handle driver setup input data from the normal configuration or expert configuration screen.
 ///
 /// Validate and save entered data, then trigger the end of the setup flow with [FinishSetupFlowMsg].
 impl Handler<SetDriverUserDataMsg> for Controller {
@@ -127,8 +107,30 @@ impl Handler<SetDriverUserDataMsg> for Controller {
         }
 
         // validate setup data
+        // Plain and simple: same for all setup pages. If it gets more complex, keep track of current
+        // page as for example in the ATV integration, and only check expected fields.
         let mut cfg = self.settings.hass.clone();
         if let IntegrationSetup::InputValues(values) = msg.data {
+            if values.contains_key("url") {
+                // TODO verify WebSocket connection to make sure user provided URL & token are ok! #3
+                // Right now the core will just send a Connect request after setup...
+                let url = parse_value::<String>(&values, "url");
+                cfg.set_url(validate_url(url.as_deref())?);
+            }
+
+            if let Some(token) = parse_value::<String>(&values, "token") {
+                if token.is_empty() && !cfg.get_token().is_empty() {
+                    warn!(
+                        "[{}] no token value provided in setup, using existing token",
+                        msg.ws_id
+                    )
+                } else if !token.is_empty() {
+                    cfg.set_token(token);
+                } else {
+                    return Err(BadRequest("Missing token".into()));
+                }
+            }
+
             if let Some(value) = parse_value(&values, "connection_timeout") {
                 if value >= 3 {
                     cfg.connection_timeout = value;
@@ -188,6 +190,136 @@ impl Handler<SetDriverUserDataMsg> for Controller {
     }
 }
 
+/// Request configuration options.
+///
+/// - If the external token & URL has been set by the HA UC component, just show the configured URL.
+/// - Otherwise, show URL and token input fields.
+impl Handler<RequestOptionsMsg> for Controller {
+    type Result = ();
+
+    fn handle(&mut self, msg: RequestOptionsMsg, ctx: &mut Self::Context) -> Self::Result {
+        if self.sm_consume(&msg.ws_id, &RequestUserInput, ctx).is_err() {
+            return;
+        }
+
+        // TODO externalize i18n
+        let event = if self.settings.hass.has_external_url_and_token() {
+            WsMessage::event(
+                "driver_setup_change",
+                EventCategory::Device,
+                json!({
+                    "event_type": SetupChangeEventType::Setup,
+                    "state": IntegrationSetupState::WaitUserAction,
+                    "require_user_action": {
+                        "input": {
+                            "title": {
+                                "en": "Home Assistant settings",
+                                "de": "Home Assistant Konfiguration",
+                                "fr": "Configuration Home Assistant"
+                            },
+                            "settings": [
+                              {
+                                "id": "info",
+                                "label": {
+                                  "en": "Home Assistant Server",
+                                  "fr": "Serveur Home Assistant"
+                                },
+                                "field": {
+                                  "label": {
+                                    "value": {
+                                      "en": "The configuration has been provided by the Home Assistance UC component. Click _Next_ to connect to Home Assistant and to retrieve available entities.",
+                                      "de": "Die Konfiguration wurde durch die Home Assistance UC Komponente vorgenommen. Klicke auf _Weiter_ um auf Home Assistant zu verbinden und die verfügbaren Entitäten zu laden.",
+                                      "fr": "La configuration a été fournie par le composant Home Assistance UC. Cliquez sur _Suivant_ pour vous connecter à Home Assistant et récupérer les entités disponibles."
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "id": "url",
+                                "label": {
+                                  "en": "Configured Home Assistant WebSocket API URL:",
+                                  "de": "Konfigurierte Home Assistant WebSocket API URL:",
+                                  "fr": "URL de l'API WebSocket de Home Assistant configurée:"
+                                },
+                                "field": {
+                                  "label": {
+                                    "value": {
+                                       "en": self.settings.hass.get_url()
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                        }
+                    }
+                }),
+            )
+        } else {
+            let token_missing = self.settings.hass.get_token().is_empty();
+            WsMessage::event(
+                "driver_setup_change",
+                EventCategory::Device,
+                json!({
+                    "event_type": SetupChangeEventType::Setup,
+                    "state": IntegrationSetupState::WaitUserAction,
+                    "require_user_action": {
+                        "input": {
+                            "title": {
+                                "en": "Home Assistant settings",
+                                "de": "Home Assistant Konfiguration",
+                                "fr": "Configuration Home Assistant"
+                            },
+                            "settings": [
+                              {
+                                "id": "info",
+                                "label": {
+                                  "en": "Home Assistant Server",
+                                  "fr": "Serveur Home Assistant"
+                                },
+                                "field": {
+                                  "label": {
+                                    "value": {
+                                      "en": "The driver requires WebSocket API access to communicate with Home Assistant.\nSee [Home Assistant documentation](https://www.home-assistant.io/docs/authentication/) for more information on how to create a long lived access token.\n\nThe access token is required for setting up the integration. If the integration is reconfigured, the access token can be omitted and the previously configured token is used.",
+                                      "de": "Der Treiber benötigt WebSocket-API Zugriff, um mit Home Assistant zu kommunizieren.\nWeitere Informationen zur Erstellung eines langlebigen Zugriffstokens findest du in der [Home Assistant Dokumentation](https://www.home-assistant.io/docs/authentication/).\n\nDas Zugriffstoken wird zum Einrichten der Integration benötigt. Wird die Integration neu konfiguriert, kann das Zugriffstoken weggelassen werden und das vorher konfigurierte Token wird verwendet.",
+                                      "fr": "Le pilote nécessite l'accès à l'API WebSocket pour communiquer avec Home Assistant.\nVoir [Home Assistant documentation] (https://www.home-assistant.io/docs/authentication/) pour plus d'informations sur la création d'un \"long lived access token\".\n\nLe token d'accès est requis pour configurer l'intégration. Si l'intégration est reconfigurée, le token d'accès peut être omis et le token précédemment configuré est utilisé."
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "id": "url",
+                                "label": {
+                                  "en": "WebSocket API URL"
+                                },
+                                "field": {
+                                  "text": {
+                                    "value": self.settings.hass.get_url()
+                                  }
+                                }
+                              },
+                              {
+                                "id": "token",
+                                "label": {
+                                  "en": format!("Long lived access token {}", if token_missing { "- not yet configured!" } else { "(empty: old token)" }),
+                                  "de": format!("Langlebiges Zugriffstoken {}", if token_missing { "- noch nicht konfiguriert!" } else { "(leer: altes Token)" }),
+                                  "fr": format!("Jeton d'accès de longue durée {}", if token_missing { "- pas encore configuré!" } else { "(vide : ancien jeton)" })
+                                },
+                                "field": {
+                                  "password": {
+                                  }
+                                }
+                              }
+                            ]
+                        }
+                    }
+                }),
+            )
+        };
+
+        self.send_r2_msg(event, &msg.ws_id);
+    }
+}
+
 /// Send the expert configuration data request.
 ///
 /// The setup flow will continue with the [SetDriverUserDataMsg] or timeout if no response is received.
@@ -199,6 +331,7 @@ impl Handler<RequestExpertOptionsMsg> for Controller {
             return;
         }
 
+        // TODO externalize i18n
         let event = WsMessage::event(
             "driver_setup_change",
             EventCategory::Device,
@@ -465,14 +598,14 @@ impl Handler<AbortDriverSetup> for Controller {
             }
 
             // Continue normal operation if it was a reconfiguration and not an initial setup.
-            // Otherwise we'll always get a "setup required" when requesting entities in the web-configurator.
+            // Otherwise, we'll always get a "setup required" when requesting entities in the web-configurator.
             if let Some(session) = self.sessions.get_mut(&msg.ws_id) {
                 let reconfiguring = session.reconfiguring;
                 session.reconfiguring = None;
                 if matches!(self.machine.state(), &OperationModeState::RequireSetup)
                     && reconfiguring == Some(true)
-                    && self.settings.hass.url.has_host()
-                    && !self.settings.hass.token.is_empty()
+                    && self.settings.hass.get_url().has_host()
+                    && !self.settings.hass.get_token().is_empty()
                 {
                     let _ = self.sm_consume(&msg.ws_id, &ConfigurationAvailable, ctx);
                     ctx.notify(ConnectMsg::default());

--- a/src/controller/handler/setup.rs
+++ b/src/controller/handler/setup.rs
@@ -669,6 +669,7 @@ fn validate_url<'a>(addr: impl Into<Option<&'a str>>) -> Result<Url, ServiceErro
 
 fn parse_with_ws_scheme(address: &str) -> Result<Url, url::ParseError> {
     let address = format!("ws://{address}");
+    #[allow(clippy::manual_inspect)] // first we need to set `rust-version = "1.81"` in Cargo.toml
     Url::parse(&address).map_err(|e| {
         warn!("Invalid URL '{address}': {e}");
         e

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -113,8 +113,9 @@ pub struct Controller {
 impl Controller {
     pub fn new(settings: Settings, drv_metadata: IntegrationDriverUpdate) -> Self {
         let mut machine = StateMachine::new();
+        let url = settings.hass.get_url();
         // if we have all required HA connection settings, we can skip driver setup
-        if settings.hass.url.has_host() && !settings.hass.token.is_empty() {
+        if url.has_host() && !settings.hass.get_token().is_empty() {
             let _ = machine.consume(&OperationModeInput::ConfigurationAvailable);
         } else {
             info!("Home Assistant connection requires setup");
@@ -125,7 +126,7 @@ impl Controller {
             ws_client: new_websocket_client(
                 Duration::from_secs(settings.hass.connection_timeout as u64),
                 Duration::from_secs(settings.hass.request_timeout as u64),
-                matches!(settings.hass.url.scheme(), "wss" | "https"),
+                matches!(url.scheme(), "wss" | "https"),
             ),
             ha_reconnect_duration: settings.hass.reconnect.duration,
             settings,

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -159,8 +159,12 @@ impl Controller {
                 debug!("Remote is in standby, not sending message: {:?}", message);
                 return;
             }
+            let msg = message.msg.clone();
             if let Err(e) = session.recipient.try_send(SendWsMessage(message)) {
-                error!("[{ws_id}] Internal message send error: {e}");
+                error!(
+                    "[{ws_id}] Internal message send error of '{}': {e}",
+                    msg.unwrap_or_default()
+                );
             }
         } else {
             warn!("attempting to send message but couldn't find session: {ws_id}");

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -56,6 +56,8 @@ state_machine! {
 
 struct R2Session {
     recipient: Recipient<SendWsMessage>,
+    /// Request message id from driver to remote
+    ws_id: u32,
     standby: bool,
     subscribed_entities: HashSet<String>,
     // TODO replace with request id map & oneshot notification
@@ -71,12 +73,18 @@ impl R2Session {
     fn new(recipient: Recipient<SendWsMessage>) -> Self {
         Self {
             recipient,
+            ws_id: 0,
             standby: false,
             subscribed_entities: Default::default(),
             get_available_entities_id: None,
             get_entity_states_id: None,
             reconfiguring: None,
         }
+    }
+
+    fn new_msg_id(&mut self) -> u32 {
+        self.ws_id += 1;
+        self.ws_id
     }
 }
 
@@ -108,6 +116,8 @@ pub struct Controller {
     reconnect_handle: Option<SpawnHandle>,
     /// List of subscribed entities sent by HA component
     susbcribed_entity_ids: Option<Vec<AvailableIntgEntity>>,
+    /// Request id sent to the remote to get the version information
+    remote_id: String,
 }
 
 impl Controller {
@@ -138,6 +148,7 @@ impl Controller {
             setup_timeout: None,
             reconnect_handle: None,
             susbcribed_entity_ids: None,
+            remote_id: "".to_string(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,9 +113,10 @@ struct Listeners {
 }
 
 fn create_tcp_listeners(cfg: &IntegrationSettings) -> Result<Listeners, io::Error> {
+    let version = built_info::GIT_VERSION.unwrap_or(built_info::PKG_VERSION);
     let listener = if cfg.http.enabled {
         let address = format!("{}:{}", cfg.interface, cfg.http.port);
-        println!("{} listening on: {address}", built_info::PKG_NAME);
+        println!("{} {version} listening on: {address}", built_info::PKG_NAME);
         Some(TcpListener::bind(address)?)
     } else {
         None
@@ -131,7 +132,7 @@ fn create_tcp_listeners(cfg: &IntegrationSettings) -> Result<Listeners, io::Erro
             Some(c) => c.clone(),
         };
 
-        println!("{} listening on: {address}", built_info::PKG_NAME);
+        println!("{} {version} listening on: {address}", built_info::PKG_NAME);
         (Some(TcpListener::bind(address)?), certs)
     } else {
         (None, Default::default())

--- a/src/server/ws/connection.rs
+++ b/src/server/ws/connection.rs
@@ -29,6 +29,10 @@ impl Actor for WsConn {
     type Context = WebsocketContext<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
+        // Noticed `send failed because receiver is full` errors with the default 16.
+        // Likely due to rapid entity updates from HA.
+        ctx.set_mailbox_capacity(32);
+
         self.start_heartbeat(ctx);
 
         // since we only implemented the header based authentication in server::ws_index we can send


### PR DESCRIPTION
Add support for the [Unfolded Circle for Home Assistant component](https://github.com/JackJPowell/hass-unfoldedcircle) for optimized message communication and automatic configuration.

The Home Assistant URL and access token can be set with an external system token.

The REST Core-API allows to set external system token information with the `/auth/external/:system` endpoint.

- `system`: relates to the `driver_id`.
  For the integration running on the device, this is `hass`.
- The `token_id` field in the POST payload must have the value `ws-ha-api`.
- The `token` field in the POST payload must contain the long-lived access token.
- The option field `url` must contain the HA WebSocket API endpoint.

Example POST request:
```json
{
    "token_id": "ws-api",
    "name": "API access token",
    "token": "123456789...........................",
    "description": "URL and long lived access token for Home Assistant WebSocket API",
    "url": "http://192.168.2.34/"
}
```

Other fixes:
- Check for available URL and token before connecting to HA to avoid initial failed HA login attempt.
- Increase queue size for sending WebSocket messages, which should avoid `send failed because receiver is full` errors. This error occurs when HA sends many change events in a short time.