### PR TITLE
Fix Docker image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
   build:
     name: Linux-x64 build
     needs: test
+    # Attention: target is a Debian bookworm Docker image. Ubuntu 24.04 glibc version isn't compatible!
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -336,8 +337,7 @@ jobs:
 
   release:
     name: GitHub release
-    # !!! DISABLED FOR PR TESTING
-    # if: github.ref == 'refs/heads/main' || contains(github.ref, 'tags/v')
+    if: github.ref == 'refs/heads/main' || contains(github.ref, 'tags/v')
     needs: [ build, cross_compile, tools, changelog ]
     runs-on: ubuntu-24.04
 
@@ -433,8 +433,7 @@ jobs:
 
   container:
     name: Create Docker image
-    # !!! DISABLED FOR PR TESTING
-    # if: "contains(github.ref, 'tags/v')" # only publish releases!
+    if: "contains(github.ref, 'tags/v')" # only publish releases!
     runs-on: ubuntu-24.04
     needs: release
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
   test:
     # run tests & clippy in same job for improved caching & faster builds
     name: Test and clippy
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
   build:
     name: Linux-x64 build
     needs: test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -240,7 +240,7 @@ jobs:
           - {
             name: "ha-test Linux-x64",
             target: "Linux-x64",
-            os: "ubuntu-24.04",
+            os: "ubuntu-22.04",
             artifact: "ha-test",
             archive: "ha-test_Linux-x64.tar.gz"
           }
@@ -336,7 +336,8 @@ jobs:
 
   release:
     name: GitHub release
-    if: github.ref == 'refs/heads/main' || contains(github.ref, 'tags/v')
+    # !!! DISABLED FOR PR TESTING
+    # if: github.ref == 'refs/heads/main' || contains(github.ref, 'tags/v')
     needs: [ build, cross_compile, tools, changelog ]
     runs-on: ubuntu-24.04
 
@@ -432,7 +433,8 @@ jobs:
 
   container:
     name: Create Docker image
-    if: "contains(github.ref, 'tags/v')" # only publish releases!
+    # !!! DISABLED FOR PR TESTING
+    # if: "contains(github.ref, 'tags/v')" # only publish releases!
     runs-on: ubuntu-24.04
     needs: release
 


### PR DESCRIPTION
Reverting Linux target build images to use Ubuntu 22.04, which has a compatible glibc version for Debian bookworm Docker image.

Ubuntu 22.04 is supported until April 2027: https://ubuntu.com/about/release-cycle

Docker image works again:
```
docker run --rm --name uc-intg-hass \
  -p 8000:8000 \
  unfoldedcircle/integration-hass:latest
[2025-02-12T17:22:56Z INFO  uc_intg_hass] Loading default configuration file: configuration.yaml
[2025-02-12T17:22:56Z INFO  uc_intg_hass::configuration] No user settings file found
uc-intg-hass v0.12.0-1-gff8f9b2 listening on: 0.0.0.0:8000
```

Fixes #64 