### PR TITLE
New media player attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+---
+
+## v0.12.2 - 2025-04-17
 ### Added
 - Propagate media player attribute `media_position_updated_at`.
-
 ### Fixed
 - Media player `media_type` attribute value should be upper case to match entity documentation.
-
 ### Changed
 - update README and driver description ([#67](https://github.com/unfoldedcircle/integration-home-assistant/pull/67)).
-
----
 
 ## v0.12.1 - 2025-02-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- Propagate media player attribute `media_position_updated_at`.
+
 ### Fixed
 - Media player `media_type` attribute value should be upper case to match entity documentation.
+
 ### Changed
 - update README and driver description ([#67](https://github.com/unfoldedcircle/integration-home-assistant/pull/67)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Fixed
+- Media player `media_type` attribute value should be upper case to match entity documentation.
+### Changed
+- update README and driver description ([#67](https://github.com/unfoldedcircle/integration-home-assistant/pull/67)).
+
 ---
 
 ## v0.12.1 - 2025-02-17

--- a/src/client/entity/media_player.rs
+++ b/src/client/entity/media_player.rs
@@ -60,7 +60,9 @@ pub(crate) fn map_media_player_attributes(
         json::move_entry(ha_attr, &mut attributes, "media_title");
         json::move_entry(ha_attr, &mut attributes, "media_artist");
         json::move_value(ha_attr, &mut attributes, "media_album_name", "media_album");
-        json::move_value(ha_attr, &mut attributes, "media_content_type", "media_type");
+        if let Some(value) = ha_attr.get("media_content_type").and_then(|v| v.as_str()) {
+            attributes.insert("media_type".into(), value.to_uppercase().into());
+        }
         json::move_entry(ha_attr, &mut attributes, "shuffle");
         if let Some(value) = ha_attr.get("repeat").and_then(|v| v.as_str()) {
             attributes.insert("repeat".into(), value.to_uppercase().into());

--- a/src/client/entity/media_player.rs
+++ b/src/client/entity/media_player.rs
@@ -56,6 +56,7 @@ pub(crate) fn map_media_player_attributes(
         }
         json::move_value(ha_attr, &mut attributes, "is_volume_muted", "muted");
         json::move_entry(ha_attr, &mut attributes, "media_position");
+        json::move_entry(ha_attr, &mut attributes, "media_position_updated_at");
         json::move_entry(ha_attr, &mut attributes, "media_duration");
         json::move_entry(ha_attr, &mut attributes, "media_title");
         json::move_entry(ha_attr, &mut attributes, "media_artist");


### PR DESCRIPTION
- Propagate media player attribute `media_position_updated_at`.
  - Relates to https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/443
- Media player `media_type` attribute value should be upper case as in the entity documentation.
  This will fix the `UNKNOWN` display in the UI for most media types.