### PR TITLE
Add unit tests for entity and service conversions

### DIFF
--- a/src/client/entity/cover.rs
+++ b/src/client/entity/cover.rs
@@ -116,3 +116,459 @@ pub(crate) fn convert_cover_entity(
         attributes,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::json;
+    use uc_api::{CoverFeature, EntityType};
+
+    #[test]
+    fn convert_cover_entity_basic() {
+        let entity_id = "cover.living_room_blinds".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Living Room Blinds"
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id.clone(), state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(entity_id, entity.entity_id);
+        assert_eq!(EntityType::Cover, entity.entity_type);
+        assert_eq!(None, entity.device_class);
+        assert_eq!(
+            Some(&"Living Room Blinds".to_string()),
+            entity.name.get("en")
+        );
+        assert!(entity.features.is_some());
+        assert!(entity.attributes.is_some());
+    }
+
+    #[test]
+    fn convert_cover_entity_no_friendly_name() {
+        let entity_id = "cover.bedroom_curtains".to_string();
+        let state = "closed".to_string();
+        let mut ha_attr = serde_json::from_value(json!({})).unwrap();
+
+        let result = convert_cover_entity(entity_id.clone(), state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(Some(&entity_id), entity.name.get("en"));
+    }
+
+    #[rstest]
+    #[case("blind")]
+    #[case("curtain")]
+    #[case("garage")]
+    #[case("shade")]
+    fn convert_cover_entity_with_supported_device_classes(#[case] device_class: &str) {
+        let entity_id = format!("cover.{}_{}", device_class, "test");
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": format!("Test {}", device_class),
+            "device_class": device_class
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Failed for device class: {}", device_class);
+        let entity = result.unwrap();
+        assert_eq!(Some(device_class.to_string()), entity.device_class);
+    }
+
+    #[rstest]
+    #[case("window")]
+    #[case("door")]
+    #[case("invalid_class")]
+    #[case("")]
+    fn convert_cover_entity_with_unsupported_device_classes(#[case] device_class: &str) {
+        let entity_id = "cover.unsupported_test".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Unsupported Test",
+            "device_class": device_class
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(
+            result.is_ok(),
+            "Failed for unsupported device class: {}",
+            device_class
+        );
+        let entity = result.unwrap();
+        assert_eq!(None, entity.device_class);
+    }
+
+    #[rstest]
+    #[case("open")]
+    #[case("opening")]
+    #[case("closed")]
+    #[case("closing")]
+    #[case("unavailable")]
+    #[case("unknown")]
+    fn convert_cover_entity_all_states(#[case] state: &str) {
+        let entity_id = format!("cover.state_test_{}", state);
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": format!("State Test {}", state)
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state.to_string(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Failed for state: {}", state);
+        let entity = result.unwrap();
+        assert!(entity.attributes.is_some());
+
+        let attributes = entity.attributes.unwrap();
+        match state {
+            "open" => assert_eq!(Some(&json!("OPEN")), attributes.get("state")),
+            "opening" => assert_eq!(Some(&json!("OPENING")), attributes.get("state")),
+            "closed" => assert_eq!(Some(&json!("CLOSED")), attributes.get("state")),
+            "closing" => assert_eq!(Some(&json!("CLOSING")), attributes.get("state")),
+            "unavailable" => assert_eq!(Some(&json!("UNAVAILABLE")), attributes.get("state")),
+            "unknown" => assert_eq!(Some(&json!("UNKNOWN")), attributes.get("state")),
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn convert_cover_entity_no_features() {
+        let entity_id = "cover.basic".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Basic Cover",
+            "supported_features": 0
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        // Should have no features
+        assert_eq!(0, features.len());
+    }
+
+    #[test]
+    fn convert_cover_entity_with_open_feature() {
+        let entity_id = "cover.open_only".to_string();
+        let state = "closed".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Open Only Cover",
+            "supported_features": COVER_SUPPORT_OPEN
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        assert_eq!(1, features.len());
+        assert!(features.contains(&CoverFeature::Open.to_string()));
+        assert!(!features.contains(&CoverFeature::Close.to_string()));
+    }
+
+    #[test]
+    fn convert_cover_entity_with_close_feature() {
+        let entity_id = "cover.close_only".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Close Only Cover",
+            "supported_features": COVER_SUPPORT_CLOSE
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        assert_eq!(1, features.len());
+        assert!(features.contains(&CoverFeature::Close.to_string()));
+        assert!(!features.contains(&CoverFeature::Open.to_string()));
+    }
+
+    #[test]
+    fn convert_cover_entity_with_stop_feature() {
+        let entity_id = "cover.stop_only".to_string();
+        let state = "opening".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Stop Only Cover",
+            "supported_features": COVER_SUPPORT_STOP
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        assert_eq!(1, features.len());
+        assert!(features.contains(&CoverFeature::Stop.to_string()));
+    }
+
+    #[test]
+    fn convert_cover_entity_with_position_feature() {
+        let entity_id = "cover.position_only".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Position Only Cover",
+            "supported_features": COVER_SUPPORT_SET_POSITION
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        assert_eq!(1, features.len());
+        assert!(features.contains(&CoverFeature::Position.to_string()));
+    }
+
+    #[test]
+    fn convert_cover_entity_with_all_features() {
+        let entity_id = "cover.full_featured".to_string();
+        let state = "open".to_string();
+        let supported_features = COVER_SUPPORT_OPEN
+            | COVER_SUPPORT_CLOSE
+            | COVER_SUPPORT_STOP
+            | COVER_SUPPORT_SET_POSITION;
+
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Full Featured Cover",
+            "supported_features": supported_features
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        assert_eq!(4, features.len());
+        assert!(features.contains(&CoverFeature::Open.to_string()));
+        assert!(features.contains(&CoverFeature::Close.to_string()));
+        assert!(features.contains(&CoverFeature::Stop.to_string()));
+        assert!(features.contains(&CoverFeature::Position.to_string()));
+    }
+
+    #[test]
+    fn convert_cover_entity_with_partial_features() {
+        let entity_id = "cover.partial".to_string();
+        let state = "closed".to_string();
+        let supported_features = COVER_SUPPORT_OPEN | COVER_SUPPORT_CLOSE;
+
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Partial Cover",
+            "supported_features": supported_features
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        assert_eq!(2, features.len());
+        assert!(features.contains(&CoverFeature::Open.to_string()));
+        assert!(features.contains(&CoverFeature::Close.to_string()));
+        assert!(!features.contains(&CoverFeature::Stop.to_string()));
+        assert!(!features.contains(&CoverFeature::Position.to_string()));
+    }
+
+    #[test]
+    fn convert_cover_entity_missing_supported_features() {
+        let entity_id = "cover.no_features".to_string();
+        let state = "closed".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "No Features Cover"
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        // Should have no features when supported_features is missing
+        assert_eq!(0, features.len());
+    }
+
+    #[test]
+    fn convert_cover_entity_invalid_supported_features() {
+        let entity_id = "cover.invalid_features".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Invalid Features Cover",
+            "supported_features": "not_a_number"
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        let features = entity.features.unwrap();
+
+        // Should default to 0 and have no features
+        assert_eq!(0, features.len());
+    }
+
+    #[test]
+    fn convert_cover_entity_structure() {
+        let entity_id = "cover.structure_test".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Structure Test Cover"
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id.clone(), state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+
+        // Verify required fields
+        assert_eq!(entity_id, entity.entity_id);
+        assert_eq!(None, entity.device_id);
+        assert_eq!(EntityType::Cover, entity.entity_type);
+        assert_eq!(None, entity.area);
+        assert_eq!(None, entity.options);
+        assert!(entity.name.contains_key("en"));
+        assert!(entity.features.is_some());
+        assert!(entity.attributes.is_some());
+    }
+
+    #[test]
+    fn convert_cover_entity_with_position_attributes() {
+        let entity_id = "cover.position_cover".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Position Cover",
+            "supported_features": COVER_SUPPORT_SET_POSITION,
+            "current_position": 75
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert!(entity.attributes.is_some());
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(Some(&json!("OPEN")), attributes.get("state"));
+        assert_eq!(Some(&json!(75)), attributes.get("position"));
+    }
+
+    #[test]
+    fn convert_cover_entity_with_tilt_position_attributes() {
+        let entity_id = "cover.tilt_cover".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Tilt Cover",
+            "current_tilt_position": 45
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert!(entity.attributes.is_some());
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(Some(&json!("OPEN")), attributes.get("state"));
+        assert_eq!(Some(&json!(45)), attributes.get("tilt_position"));
+    }
+
+    #[test]
+    fn convert_cover_entity_with_invalid_position_attributes() {
+        let entity_id = "cover.invalid_position".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Invalid Position Cover",
+            "current_position": 150,  // Invalid: > 100
+            "current_tilt_position": -10  // Invalid: < 0
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert!(entity.attributes.is_some());
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(Some(&json!("OPEN")), attributes.get("state"));
+        // Invalid values should be ignored
+        assert!(attributes.get("position").is_none());
+        assert!(attributes.get("tilt_position").is_none());
+    }
+
+    #[test]
+    fn convert_cover_entity_with_both_position_attributes() {
+        let entity_id = "cover.both_positions".to_string();
+        let state = "open".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Both Positions Cover",
+            "current_position": 80,
+            "current_tilt_position": 60
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert!(entity.attributes.is_some());
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(Some(&json!("OPEN")), attributes.get("state"));
+        assert_eq!(Some(&json!(80)), attributes.get("position"));
+        assert_eq!(Some(&json!(60)), attributes.get("tilt_position"));
+    }
+
+    #[test]
+    fn convert_cover_entity_with_device_class_and_features() {
+        let entity_id = "cover.garage_door".to_string();
+        let state = "closed".to_string();
+        let mut ha_attr = serde_json::from_value(json!({
+            "friendly_name": "Garage Door",
+            "device_class": "garage",
+            "supported_features": COVER_SUPPORT_OPEN | COVER_SUPPORT_CLOSE | COVER_SUPPORT_STOP
+        }))
+        .unwrap();
+
+        let result = convert_cover_entity(entity_id, state, &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+
+        assert_eq!(Some("garage".to_string()), entity.device_class);
+        let features = entity.features.unwrap();
+        assert_eq!(3, features.len());
+        assert!(features.contains(&CoverFeature::Open.to_string()));
+        assert!(features.contains(&CoverFeature::Close.to_string()));
+        assert!(features.contains(&CoverFeature::Stop.to_string()));
+    }
+}

--- a/src/client/entity/remote.rs
+++ b/src/client/entity/remote.rs
@@ -178,9 +178,20 @@ mod tests {
           }
         });
         let ha_entity = ha_entity.as_object_mut().unwrap();
-        let entity_id = ha_entity.get("entity_id").and_then(|v| v.as_str()).unwrap().to_string();
-        let state = ha_entity.get("state").and_then(|v| v.as_str()).unwrap().to_string();
-        let attr = ha_entity.get_mut("attributes").and_then(|v| v.as_object_mut()).unwrap();
+        let entity_id = ha_entity
+            .get("entity_id")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let state = ha_entity
+            .get("state")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let attr = ha_entity
+            .get_mut("attributes")
+            .and_then(|v| v.as_object_mut())
+            .unwrap();
         let result = convert_remote_entity(entity_id, state, attr).unwrap();
 
         // Expect OFF mapping
@@ -200,9 +211,20 @@ mod tests {
           }
         });
         let ha_entity = ha_entity.as_object_mut().unwrap();
-        let entity_id = ha_entity.get("entity_id").and_then(|v| v.as_str()).unwrap().to_string();
-        let state = ha_entity.get("state").and_then(|v| v.as_str()).unwrap().to_string();
-        let attr = ha_entity.get_mut("attributes").and_then(|v| v.as_object_mut()).unwrap();
+        let entity_id = ha_entity
+            .get("entity_id")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let state = ha_entity
+            .get("state")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let attr = ha_entity
+            .get_mut("attributes")
+            .and_then(|v| v.as_object_mut())
+            .unwrap();
         let result = convert_remote_entity(entity_id, state, attr).unwrap();
         let attr = result.attributes.unwrap();
         assert_eq!(Some(&json!("UNKNOWN")), attr.get("state"));
@@ -218,9 +240,20 @@ mod tests {
           }
         });
         let ha_entity = ha_entity.as_object_mut().unwrap();
-        let entity_id = ha_entity.get("entity_id").and_then(|v| v.as_str()).unwrap().to_string();
-        let state = ha_entity.get("state").and_then(|v| v.as_str()).unwrap().to_string();
-        let attr = ha_entity.get_mut("attributes").and_then(|v| v.as_object_mut()).unwrap();
+        let entity_id = ha_entity
+            .get("entity_id")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let state = ha_entity
+            .get("state")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        let attr = ha_entity
+            .get_mut("attributes")
+            .and_then(|v| v.as_object_mut())
+            .unwrap();
         let result = convert_remote_entity(entity_id, state, attr);
         assert!(result.is_err(), "Expected error for invalid state");
     }

--- a/src/client/entity/sensor.rs
+++ b/src/client/entity/sensor.rs
@@ -122,3 +122,269 @@ fn device_class_to_label(class: &str) -> Option<String> {
     c.next()
         .map(|f| f.to_uppercase().collect::<String>() + c.as_str())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use uc_api::{SensorAttribute, SensorDeviceClass};
+
+    #[test]
+    fn convert_sensor_entity_mappings() {
+        let entity_id = "sensor.temperature".to_string();
+        let state = "23.5".to_string();
+        let mut ha_attr = serde_json::Map::new();
+        ha_attr.insert(
+            "friendly_name".to_string(),
+            json!("Living Room Temperature"),
+        );
+        ha_attr.insert("device_class".to_string(), json!("temperature"));
+        ha_attr.insert("unit_of_measurement".to_string(), json!("°C"));
+
+        let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(entity_id, entity.entity_id);
+        assert_eq!(EntityType::Sensor, entity.entity_type);
+        assert_eq!(Some("temperature".to_string()), entity.device_class);
+        assert_eq!("Living Room Temperature", entity.name.get("en").unwrap());
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(
+            Some(&json!("ON")),
+            attributes.get(SensorAttribute::State.as_ref())
+        );
+        assert_eq!(
+            Some(&json!("23.5")),
+            attributes.get(SensorAttribute::Value.as_ref())
+        );
+        assert_eq!(
+            Some(&json!("°C")),
+            attributes.get(SensorAttribute::Unit.as_ref())
+        );
+    }
+
+    #[test]
+    fn convert_binary_sensor_entity() {
+        let entity_id = "binary_sensor.door_sensor".to_string();
+        let state = "on".to_string();
+        let mut ha_attr = serde_json::Map::new();
+        ha_attr.insert("friendly_name".to_string(), json!("Front Door"));
+        ha_attr.insert("device_class".to_string(), json!("door"));
+
+        let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(entity_id, entity.entity_id);
+        assert_eq!(
+            Some(SensorDeviceClass::Binary.to_string()),
+            entity.device_class
+        );
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(
+            Some(&json!("ON")),
+            attributes.get(SensorAttribute::State.as_ref())
+        );
+        assert_eq!(
+            Some(&json!("on")),
+            attributes.get(SensorAttribute::Value.as_ref())
+        );
+        assert_eq!(
+            Some(&json!("door")),
+            attributes.get(SensorAttribute::Unit.as_ref())
+        );
+    }
+
+    #[test]
+    fn convert_sensor_entity_with_supported_device_classes() {
+        let supported_classes = vec![
+            "battery",
+            "current",
+            "energy",
+            "humidity",
+            "power",
+            "temperature",
+            "voltage",
+        ];
+
+        for device_class in supported_classes {
+            let entity_id = format!("sensor.test_{}", device_class);
+            let state = "100".to_string();
+            let mut ha_attr = serde_json::Map::new();
+            ha_attr.insert("device_class".to_string(), json!(device_class));
+            ha_attr.insert("unit_of_measurement".to_string(), json!("unit"));
+
+            let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+            assert!(result.is_ok(), "Failed for device class: {}", device_class);
+            let entity = result.unwrap();
+            assert_eq!(Some(device_class.to_string()), entity.device_class);
+        }
+    }
+
+    #[test]
+    fn convert_sensor_entity_without_friendly_name_maps_name_to_entity_id() {
+        let entity_id = "sensor.unnamed".to_string();
+        let state = "42".to_string();
+        let mut ha_attr = serde_json::Map::new();
+        ha_attr.insert("device_class".to_string(), json!("power"));
+
+        let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(
+            Some(SensorDeviceClass::Power.to_string()),
+            entity.device_class
+        );
+        assert_eq!(&entity_id, entity.name.get("en").unwrap());
+    }
+
+    #[test]
+    fn convert_sensor_entity_without_device_class_maps_to_custom() {
+        let entity_id = "sensor.generic".to_string();
+        let state = "unknown".to_string();
+        let unit = "units";
+        let mut ha_attr = serde_json::Map::new();
+        ha_attr.insert("friendly_name".to_string(), json!("Generic Sensor"));
+        ha_attr.insert("unit_of_measurement".to_string(), json!(unit));
+
+        let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(
+            Some(SensorDeviceClass::Custom.to_string()),
+            entity.device_class
+        );
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(
+            Some(&json!(unit)),
+            attributes.get(SensorAttribute::Unit.as_ref())
+        );
+    }
+
+    #[test]
+    fn convert_sensor_entity_unavailable_state() {
+        let entity_id = "sensor.offline".to_string();
+        let state = "unavailable".to_string();
+        let mut ha_attr = serde_json::Map::new();
+        ha_attr.insert("friendly_name".to_string(), json!("Offline Sensor"));
+        ha_attr.insert("device_class".to_string(), json!("temperature"));
+
+        let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(
+            Some(SensorDeviceClass::Temperature.to_string()),
+            entity.device_class
+        );
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(
+            Some(&json!("UNAVAILABLE")),
+            attributes.get(SensorAttribute::State.as_ref())
+        );
+        assert_eq!(
+            Some(&json!(state)),
+            attributes.get(SensorAttribute::Value.as_ref())
+        );
+    }
+
+    #[test]
+    fn convert_sensor_entity_with_unknown_state() {
+        let entity_id = "sensor.mystery".to_string();
+        let state = "unknown".to_string();
+        let mut ha_attr = serde_json::Map::new();
+        ha_attr.insert("friendly_name".to_string(), json!("Mystery Sensor"));
+        ha_attr.insert("device_class".to_string(), json!("humidity"));
+
+        let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(
+            Some(&json!("UNKNOWN")),
+            attributes.get(SensorAttribute::State.as_ref())
+        );
+        assert_eq!(
+            Some(&json!(state)),
+            attributes.get(SensorAttribute::Value.as_ref())
+        );
+    }
+
+    #[test]
+    fn convert_sensor_entity_binary_sensor_with_invalid_state_maps_to_on_state() {
+        let entity_id = "binary_sensor.generic".to_string();
+        let state = "off".to_string(); // sensors have no off state
+        let mut ha_attr = serde_json::Map::new();
+        ha_attr.insert("friendly_name".to_string(), json!("Generic Binary"));
+
+        let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(
+            Some(SensorDeviceClass::Binary.to_string()),
+            entity.device_class
+        );
+
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(
+            Some(&json!("ON")),
+            attributes.get(SensorAttribute::State.as_ref())
+        );
+        assert_eq!(
+            Some(&json!(state)),
+            attributes.get(SensorAttribute::Value.as_ref())
+        );
+        // No unit should be set when device_class is missing
+        assert!(
+            attributes.get(SensorAttribute::Unit.as_ref()).is_none(),
+            "No unit expected"
+        );
+    }
+
+    #[test]
+    fn convert_sensor_entity_with_unsupported_device_class_maps_to_custom() {
+        let entity_id = "sensor.pressure_sensor".to_string();
+        let state = "1013.25".to_string();
+        let friendly_name = "Pressure Sensor";
+        let unit = "hPa";
+
+        let mut ha_attr = serde_json::Map::new();
+        ha_attr.insert("friendly_name".to_string(), json!(friendly_name));
+        ha_attr.insert("device_class".to_string(), json!("atmospheric_pressure"));
+        ha_attr.insert("unit_of_measurement".to_string(), json!(unit));
+
+        let result = convert_sensor_entity(entity_id.clone(), state.clone(), &mut ha_attr);
+
+        assert!(result.is_ok(), "Expected converted entity: {result:?}");
+        let entity = result.unwrap();
+        assert_eq!(friendly_name, entity.name.get("en").unwrap());
+        assert_eq!(
+            entity.device_class,
+            Some(SensorDeviceClass::Custom.to_string())
+        );
+        let attributes = entity.attributes.unwrap();
+        assert_eq!(
+            Some(&json!("ON")),
+            attributes.get(SensorAttribute::State.as_ref())
+        );
+        assert_eq!(
+            Some(&json!(state)),
+            attributes.get(SensorAttribute::Value.as_ref())
+        );
+        assert_eq!(
+            Some(&json!(unit)),
+            attributes.get(SensorAttribute::Unit.as_ref())
+        );
+    }
+}

--- a/src/client/service/button.rs
+++ b/src/client/service/button.rs
@@ -26,3 +26,175 @@ pub(crate) fn handle_button(msg: &EntityCommand) -> Result<(String, Option<Value
 
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::client::service::button::handle_button;
+    use rstest::rstest;
+    use uc_api::EntityType;
+    use uc_api::intg::EntityCommand;
+
+    fn new_entity_command(
+        entity_id: impl Into<String>,
+        cmd_id: impl Into<String>,
+    ) -> EntityCommand {
+        EntityCommand {
+            device_id: None,
+            entity_type: EntityType::Button,
+            entity_id: entity_id.into(),
+            cmd_id: cmd_id.into(),
+            params: None,
+        }
+    }
+
+    #[rstest]
+    #[case("script.foobar", "foobar")]
+    #[case("script.turn_on_lights", "turn_on_lights")]
+    #[case("script.complex_script_123", "complex_script_123")]
+    fn script_entities_use_script_name_as_service(
+        #[case] entity_id: &str,
+        #[case] expected_service: &str,
+    ) {
+        let cmd = new_entity_command(entity_id, "push");
+        let result = handle_button(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid script entity must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!(expected_service, &service);
+        assert!(
+            param.is_none(),
+            "Button commands should not have parameters"
+        );
+    }
+
+    #[rstest]
+    #[case("scene.morning", "turn_on")]
+    #[case("scene.evening", "turn_on")]
+    #[case("scene.party_mode", "turn_on")]
+    fn scene_entities_use_turn_on_service(#[case] entity_id: &str, #[case] expected_service: &str) {
+        let cmd = new_entity_command(entity_id, "push");
+        let result = handle_button(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid scene entity must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!(expected_service, &service);
+        assert!(
+            param.is_none(),
+            "Button commands should not have parameters"
+        );
+    }
+
+    #[rstest]
+    #[case("button.doorbell", "press")]
+    #[case("input_button.test_button", "press")]
+    #[case("automation.my_automation", "press")]
+    #[case("switch.some_switch", "press")]
+    #[case("light.some_light", "press")]
+    #[case("unknown.entity_type", "press")]
+    fn other_entities_use_press_service(#[case] entity_id: &str, #[case] expected_service: &str) {
+        let cmd = new_entity_command(entity_id, "push");
+        let result = handle_button(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid entity must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!(expected_service, &service);
+        assert!(
+            param.is_none(),
+            "Button commands should not have parameters"
+        );
+    }
+
+    #[test]
+    fn entity_id_without_domain_separator_uses_press_service() {
+        let cmd = new_entity_command("no_separator_entity", "push");
+        let result = handle_button(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Entity without separator must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("press", &service);
+        assert!(
+            param.is_none(),
+            "Button commands should not have parameters"
+        );
+    }
+
+    #[test]
+    fn script_entity_with_multiple_dots_uses_first_part_after_domain() {
+        let cmd = new_entity_command("script.my.complex.script.name", "push");
+        let result = handle_button(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Script with multiple dots must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("my", &service);
+        assert!(
+            param.is_none(),
+            "Button commands should not have parameters"
+        );
+    }
+
+    #[test]
+    fn scene_entity_with_multiple_dots_uses_turn_on() {
+        let cmd = new_entity_command("scene.my.complex.scene.name", "push");
+        let result = handle_button(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Scene with multiple dots must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("turn_on", &service);
+        assert!(
+            param.is_none(),
+            "Button commands should not have parameters"
+        );
+    }
+
+    #[test]
+    fn invalid_command_returns_error() {
+        let cmd = new_entity_command("button.test", "invalid_command");
+        let result = handle_button(&cmd);
+
+        assert!(result.is_err(), "Invalid command should return error");
+    }
+
+    #[test]
+    fn push_command_is_case_sensitive() {
+        let cmd = new_entity_command("button.test", "push");
+        let result = handle_button(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Lowercase 'push' command must work, but got: {:?}",
+            result.unwrap_err()
+        );
+
+        let cmd_upper = new_entity_command("button.test", "PUSH");
+        let result_upper = handle_button(&cmd_upper);
+
+        assert!(
+            result_upper.is_err(),
+            "Uppercase 'PUSH' command should return error due to case sensitivity"
+        );
+    }
+}

--- a/src/client/service/cover.rs
+++ b/src/client/service/cover.rs
@@ -29,3 +29,162 @@ pub(crate) fn handle_cover(msg: &EntityCommand) -> Result<(String, Option<Value>
 
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::client::service::cover::handle_cover;
+    use rstest::rstest;
+    use serde_json::{Map, Value, json};
+    use uc_api::EntityType;
+    use uc_api::intg::EntityCommand;
+
+    fn new_entity_command(cmd_id: impl Into<String>, params: Value) -> EntityCommand {
+        EntityCommand {
+            device_id: None,
+            entity_type: EntityType::Cover,
+            entity_id: "test".into(),
+            cmd_id: cmd_id.into(),
+            params: if params.is_object() {
+                Some(params.as_object().unwrap().clone())
+            } else {
+                None
+            },
+        }
+    }
+
+    #[rstest]
+    #[case("open", "open_cover")]
+    #[case("close", "close_cover")]
+    #[case("stop", "stop_cover")]
+    fn simple_commands_return_proper_service_call(
+        #[case] cmd_id: &str,
+        #[case] expected_service: &str,
+    ) {
+        let cmd = new_entity_command(cmd_id, Value::Null);
+        let result = handle_cover(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid command must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!(expected_service, &service);
+        assert!(
+            param.is_none(),
+            "Simple commands should not have parameters"
+        );
+    }
+
+    #[rstest]
+    #[case(json!(0), json!(0))]
+    #[case(json!(1), json!(1))]
+    #[case(json!(50), json!(50))]
+    #[case(json!(100), json!(100))]
+    fn position_cmd_with_valid_position_returns_proper_request(
+        #[case] position: Value,
+        #[case] expected: Value,
+    ) {
+        let cmd = new_entity_command("position", json!({ "position": position }));
+        let result = handle_cover(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid position must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("set_cover_position", &service);
+        assert!(param.is_some(), "Position command should have parameters");
+        assert_eq!(Some(&expected), param.unwrap().get("position"));
+    }
+
+    #[test]
+    fn position_cmd_without_params_returns_empty_data() {
+        let cmd = new_entity_command("position", Value::Null);
+        let result = handle_cover(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Position command without params should return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("set_cover_position", &service);
+        assert!(
+            param.is_some(),
+            "Position command should have parameters object"
+        );
+        let param_obj = param.unwrap();
+        assert!(
+            param_obj.as_object().unwrap().is_empty(),
+            "Parameters should be empty when no valid position provided"
+        );
+    }
+
+    #[rstest]
+    #[case(json!(-1))]
+    #[case(json!(101))]
+    #[case(json!(200))]
+    #[case(json!(0.0))]
+    #[case(json!(50.5))]
+    #[case(json!(true))]
+    #[case(json!(false))]
+    #[case(json!("50"))]
+    fn position_cmd_with_invalid_position_returns_empty_data(#[case] position: Value) {
+        let cmd = new_entity_command("position", json!({ "position": position }));
+        let result = handle_cover(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Position command with invalid position should return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("set_cover_position", &service);
+        assert!(
+            param.is_some(),
+            "Position command should have parameters object"
+        );
+        let param_obj = param.unwrap();
+        assert!(
+            param_obj.as_object().unwrap().is_empty(),
+            "Parameters should be empty when invalid position provided"
+        );
+    }
+
+    #[rstest]
+    #[case(Value::Object(Map::new()))]
+    #[case(json!({ "other_param": 50 }))]
+    fn position_cmd_with_missing_position_param_returns_empty_data(#[case] params: Value) {
+        let cmd = new_entity_command("position", params);
+        let result = handle_cover(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Position command with missing position param should return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("set_cover_position", &service);
+        assert!(
+            param.is_some(),
+            "Position command should have parameters object"
+        );
+        let param_obj = param.unwrap();
+        assert!(
+            param_obj.as_object().unwrap().is_empty(),
+            "Parameters should be empty when position param is missing"
+        );
+    }
+
+    #[test]
+    fn invalid_command_returns_error() {
+        let cmd = new_entity_command("invalid_command", Value::Null);
+        let result = handle_cover(&cmd);
+
+        assert!(result.is_err(), "Invalid command should return error");
+        // The specific error type depends on the cmd_from_str implementation
+        // but it should be some kind of ServiceError
+    }
+}

--- a/src/client/service/remote.rs
+++ b/src/client/service/remote.rs
@@ -28,11 +28,22 @@ pub(crate) fn handle_remote(msg: &EntityCommand) -> Result<(String, Option<Value
 }
 
 fn create_command(msg: &EntityCommand, cmd: &str) -> Result<(String, Option<Value>), ServiceError> {
+    if cmd.trim().is_empty() {
+        return Err(ServiceError::BadRequest("empty command".into()));
+    }
     let mut data = Map::new();
     let params = get_required_params(msg)?;
     if let Some(value) = params.get(cmd)
         && (cmd == "sequence" && value.is_array() || cmd == "command" && value.is_string())
     {
+        if cmd == "command"
+            && value
+                .as_str()
+                .map(|v| v.trim().is_empty())
+                .unwrap_or_default()
+        {
+            return Err(ServiceError::BadRequest("empty command".into()));
+        }
         data.insert("command".into(), value.clone());
     }
     if data.is_empty() {
@@ -59,4 +70,540 @@ fn create_command(msg: &EntityCommand, cmd: &str) -> Result<(String, Option<Valu
         data.insert("hold_secs".into(), value.into());
     }
     Ok(("send_command".into(), Some(data.into())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::ServiceError;
+    use rstest::rstest;
+    use serde_json::{Value, json};
+    use uc_api::EntityType;
+    use uc_api::intg::EntityCommand;
+
+    fn new_entity_command(cmd_id: impl Into<String>, params: Value) -> EntityCommand {
+        EntityCommand {
+            device_id: None,
+            entity_type: EntityType::Remote,
+            entity_id: "test".into(),
+            cmd_id: cmd_id.into(),
+            params: if params.is_object() {
+                Some(params.as_object().unwrap().clone())
+            } else {
+                None
+            },
+        }
+    }
+
+    #[rstest]
+    #[case("on", "turn_on")]
+    #[case("off", "turn_off")]
+    #[case("toggle", "toggle")]
+    fn basic_commands_return_correct_ha_service(
+        #[case] cmd_id: &str,
+        #[case] expected_service: &str,
+    ) {
+        let cmd = new_entity_command(cmd_id, json!({}));
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid command must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!(expected_service, &service);
+        assert_eq!(None, param);
+    }
+
+    #[test]
+    fn stop_send_command_is_not_supported_and_returns_bad_request() {
+        let cmd = new_entity_command("stop_send", json!({}));
+        let result = handle_remote(&cmd);
+
+        assert!(
+            matches!(result, Err(ServiceError::BadRequest(_))),
+            "stop_send command must return BadRequest, but got: {:?}",
+            result
+        );
+
+        if let Err(ServiceError::BadRequest(msg)) = result {
+            assert!(msg.contains("stop_send command is not supported"));
+        }
+    }
+
+    #[test]
+    fn send_cmd_with_valid_command_returns_send_command() {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "power_on"
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid send_cmd must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("power_on")), data.get("command"));
+    }
+
+    #[test]
+    fn send_cmd_sequence_with_valid_array_returns_send_command() {
+        let cmd = new_entity_command(
+            "send_cmd_sequence",
+            json!({
+                "sequence": ["power_on", "input_hdmi1", "volume_up"]
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid send_cmd_sequence must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(
+            Some(&json!(["power_on", "input_hdmi1", "volume_up"])),
+            data.get("command")
+        );
+    }
+
+    #[test]
+    fn send_cmd_with_repeat_parameter_adds_num_repeats() {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "volume_up",
+                "repeat": 3
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid send_cmd with repeat must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("volume_up")), data.get("command"));
+        assert_eq!(Some(&json!(3)), data.get("num_repeats"));
+    }
+
+    #[test]
+    fn send_cmd_with_delay_parameter_converts_to_seconds() {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "power_on",
+                "delay": 1500  // milliseconds
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid send_cmd with delay must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("power_on")), data.get("command"));
+        assert_eq!(Some(&json!(1.5)), data.get("delay_secs"));
+    }
+
+    #[test]
+    fn send_cmd_with_hold_parameter_converts_to_seconds() {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "power_button",
+                "hold": 2000  // milliseconds
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid send_cmd with hold must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("power_button")), data.get("command"));
+        assert_eq!(Some(&json!(2.0)), data.get("hold_secs"));
+    }
+
+    #[test]
+    fn send_cmd_with_all_parameters() {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "complex_command",
+                "repeat": 2,
+                "delay": 500,
+                "hold": 1000
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid send_cmd with all parameters must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("complex_command")), data.get("command"));
+        assert_eq!(Some(&json!(2)), data.get("num_repeats"));
+        assert_eq!(Some(&json!(0.5)), data.get("delay_secs"));
+        assert_eq!(Some(&json!(1.0)), data.get("hold_secs"));
+    }
+
+    #[test]
+    fn send_cmd_sequence_with_all_parameters() {
+        let cmd = new_entity_command(
+            "send_cmd_sequence",
+            json!({
+                "sequence": ["cmd1", "cmd2"],
+                "repeat": 3,
+                "delay": 250,
+                "hold": 500
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "Valid send_cmd_sequence with all parameters must return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!(["cmd1", "cmd2"])), data.get("command"));
+        assert_eq!(Some(&json!(3)), data.get("num_repeats"));
+        assert_eq!(Some(&json!(0.25)), data.get("delay_secs"));
+        assert_eq!(Some(&json!(0.5)), data.get("hold_secs"));
+    }
+
+    #[test]
+    fn send_cmd_without_command_parameter_returns_bad_request() {
+        let cmd = new_entity_command("send_cmd", json!({}));
+        let result = handle_remote(&cmd);
+
+        assert!(
+            matches!(result, Err(ServiceError::BadRequest(_))),
+            "send_cmd without command must return BadRequest, but got: {:?}",
+            result
+        );
+
+        if let Err(ServiceError::BadRequest(msg)) = result {
+            assert!(msg.contains("Invalid or missing attribute: params.command"));
+        }
+    }
+
+    #[test]
+    fn send_cmd_sequence_without_sequence_parameter_returns_bad_request() {
+        let cmd = new_entity_command("send_cmd_sequence", json!({}));
+        let result = handle_remote(&cmd);
+
+        assert!(
+            matches!(result, Err(ServiceError::BadRequest(_))),
+            "send_cmd_sequence without sequence must return BadRequest, but got: {:?}",
+            result
+        );
+
+        if let Err(ServiceError::BadRequest(msg)) = result {
+            assert!(msg.contains("Invalid or missing attribute: params.sequence"));
+        }
+    }
+
+    #[rstest]
+    #[case(json!(123))]
+    #[case(json!(true))]
+    #[case(json!(["array", "not", "string"]))]
+    #[case(json!(null))]
+    fn send_cmd_with_invalid_command_type_returns_bad_request(#[case] command: Value) {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": command
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            matches!(result, Err(ServiceError::BadRequest(_))),
+            "send_cmd with invalid command type must return BadRequest, but got: {:?}",
+            result
+        );
+    }
+
+    #[rstest]
+    #[case(json!("string"))]
+    #[case(json!(123))]
+    #[case(json!(true))]
+    #[case(json!(null))]
+    fn send_cmd_sequence_with_invalid_sequence_type_returns_bad_request(#[case] sequence: Value) {
+        let cmd = new_entity_command(
+            "send_cmd_sequence",
+            json!({
+                "sequence": sequence
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            matches!(result, Err(ServiceError::BadRequest(_))),
+            "send_cmd_sequence with invalid sequence type must return BadRequest, but got: {:?}",
+            result
+        );
+    }
+
+    #[rstest]
+    #[case(json!(""))]
+    #[case(json!(" "))]
+    #[case(json!("\n"))]
+    #[case(json!("\t"))]
+    fn send_cmd_with_empty_string_command_returns_bad_request(#[case] command: Value) {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": command
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            matches!(result, Err(ServiceError::BadRequest(_))),
+            "send_cmd_sequence with invalid sequence type must return BadRequest, but got: {:?}",
+            result
+        );
+    }
+
+    // TODO should we really allow an empty sequence?
+    #[test]
+    fn send_cmd_sequence_with_empty_array_returns_ok() {
+        let cmd = new_entity_command(
+            "send_cmd_sequence",
+            json!({
+                "sequence": []
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "send_cmd_sequence with empty array should return Ok, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!([])), data.get("command"));
+    }
+
+    #[rstest]
+    #[case(json!("not_a_number"))]
+    #[case(json!(true))]
+    #[case(json!([])) ]
+    #[case(json!(-1))]
+    fn send_cmd_with_invalid_repeat_type_ignores_parameter(#[case] repeat: Value) {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "test_cmd",
+                "repeat": repeat
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "send_cmd with invalid repeat type should still work, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("test_cmd")), data.get("command"));
+        // Invalid repeat parameter should be ignored
+        assert!(data.get("num_repeats").is_none());
+    }
+
+    #[rstest]
+    #[case(json!("not_a_number"))]
+    #[case(json!(true))]
+    #[case(json!([]))]
+    #[case(json!(-1))]
+    fn send_cmd_with_invalid_delay_type_ignores_parameter(#[case] delay: Value) {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "test_cmd",
+                "delay": delay
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "send_cmd with invalid delay type should still work, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("test_cmd")), data.get("command"));
+        // Invalid delay parameter should be ignored
+        assert!(data.get("delay_secs").is_none());
+    }
+
+    #[rstest]
+    #[case(json!("not_a_number"))]
+    #[case(json!(true))]
+    #[case(json!([]))]
+    #[case(json!(-1))]
+    fn send_cmd_with_invalid_hold_type_ignores_parameter(#[case] hold: Value) {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "test_cmd",
+                "hold": hold
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "send_cmd with invalid hold type should still work, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("test_cmd")), data.get("command"));
+        // Invalid hold parameter should be ignored
+        assert!(data.get("hold_secs").is_none());
+    }
+
+    #[test]
+    fn send_cmd_with_zero_delay_converts_correctly() {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "test_cmd",
+                "delay": 0
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "send_cmd with zero delay should work, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("test_cmd")), data.get("command"));
+        assert_eq!(Some(&json!(0.0)), data.get("delay_secs"));
+    }
+
+    #[test]
+    fn send_cmd_with_zero_hold_converts_correctly() {
+        let cmd = new_entity_command(
+            "send_cmd",
+            json!({
+                "command": "test_cmd",
+                "hold": 0
+            }),
+        );
+        let result = handle_remote(&cmd);
+
+        assert!(
+            result.is_ok(),
+            "send_cmd with zero hold should work, but got: {:?}",
+            result.unwrap_err()
+        );
+        let (service, param) = result.unwrap();
+        assert_eq!("send_command", &service);
+        assert!(param.is_some());
+
+        let data = param.unwrap();
+        assert_eq!(Some(&json!("test_cmd")), data.get("command"));
+        assert_eq!(Some(&json!(0.0)), data.get("hold_secs"));
+    }
+
+    #[test]
+    fn send_cmd_without_params_returns_bad_request() {
+        let cmd = EntityCommand {
+            device_id: None,
+            entity_type: EntityType::Remote,
+            entity_id: "test".into(),
+            cmd_id: "send_cmd".into(),
+            params: None,
+        };
+        let result = handle_remote(&cmd);
+
+        assert!(
+            matches!(result, Err(ServiceError::BadRequest(_))),
+            "send_cmd without params must return BadRequest, but got: {:?}",
+            result
+        );
+    }
+
+    #[rstest]
+    #[case("invalid_command")]
+    #[case("unknown")]
+    #[case("")]
+    fn invalid_command_ids_return_bad_request(#[case] cmd_id: &str) {
+        let cmd = new_entity_command(cmd_id, json!({}));
+        let result = handle_remote(&cmd);
+
+        assert!(
+            matches!(result, Err(ServiceError::BadRequest(_))),
+            "Invalid command '{}' must return BadRequest, but got: {:?}",
+            cmd_id,
+            result
+        );
+    }
 }


### PR DESCRIPTION
Only a few conversion functions had unit tests.

Disclaimer: AI has helped generating the test cases.
This is not perfect, but a good foundation going forward and making sure most conversion functions are covered by unit tests. This makes future changes and refactoring less risky.
